### PR TITLE
new switches --local-root and --remote-root

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,36 @@ All debugging features (breakpoints, stepping, variable inspection, threads, pro
 async tasks) work in remote attach mode. The Code View automatically navigates to the
 source file when the program stops.
 
+**Mapping remote paths to local copies (`--local-root` / `--remote-root`):** when the
+debuggee lives on another machine, or in a container, or simply in a different directory
+on the same machine, the source paths it reports (and the paths it expects breakpoints
+to refer to) won't match anything on the `tdb` host. To bridge that gap, give `tdb` one
+or more `--local-root` / `--remote-root` pairs. Each `--local-root` points at a local
+directory containing a copy of the code; each `--remote-root` is the corresponding path
+on the debuggee. The two flags must be supplied in equal numbers and are paired in CLI
+order via `zip()`, so the first `--local-root` matches the first `--remote-root`, the
+second matches the second, and so on. `debugpy` then translates paths bidirectionally:
+breakpoints set on a local file land on the matching remote file, and source paths
+returned in stopped-events / stack-traces are rewritten back to the local copy so the
+Code View loads directly from disk (no DAP `source` round-trip needed).
+
+These flags are required whenever you want to set a `-k` breakpoint against a remote
+debuggee whose code lives at a different path than your local copy. For example, if the
+remote runs `program.py` at `/path/to/code/program.py` and your local copy is at
+`/local/project/code/program.py`, set a breakpoint at line 321 with:
+
+```bash
+tdb -r RHOST:15678 \
+    --local-root /local/project/code \
+    --remote-root /path/to/code \
+    -k program.py:321
+```
+
+With `--local-root` set, a relative `-k FILE:LINE` is resolved by searching each
+`--local-root` directory in CLI order (first match wins); absolute paths still work as
+before. Multiple pairs can be supplied to mirror multiple source trees (e.g. an
+application directory and a shared library directory) in one invocation.
+
 ### External Terminal Support
 
 Some Python programs, notably text user interfaces, use terminal control
@@ -657,6 +687,7 @@ usage: tdb [-h] [-v] [-r [HOST:]PORT] [--cwd CWD] [--no-stop-on-entry]
            [--no-just-my-code] [--no-subprocess] [--python PYTHON] [--pv]
            [--keybindings {default,vim,emacs}]
            [--terminal {xterm,konsole,gnome-terminal,ghostty,kitty,iterm2,warp,wezterm,terminator}]
+           [--local-root PATH] [--remote-root PATH]
            [--server] [--headless] [-k FILE:LINE|LINE] [--server-port SERVER_PORT] [-d] [--doc-text]
            [program] [args ...]
 ```
@@ -664,6 +695,8 @@ usage: tdb [-h] [-v] [-r [HOST:]PORT] [--cwd CWD] [--no-stop-on-entry]
 | Flag | Description |
 |------|-------------|
 | `-r HOST:PORT` | Attach to a remote debugpy server |
+| `--local-root PATH` | Local directory containing a copy of remote code (repeat to mirror multiple trees). Pair with `--remote-root`; counts must match. Required when `-k` sets a breakpoint against a remote debuggee whose code lives at a different path. |
+| `--remote-root PATH` | Remote directory matched to `--local-root` (same CLI position via `zip()`). |
 | `-k`, `--breakpoint FILE:LINE|LINE` | Set a breakpoint (may be repeated). Passing `-k` implies `--no-stop-on-entry` so the program runs straight to the first breakpoint. |
 | `--no-stop-on-entry` | Do not pause at the first line (default: stop on entry; automatic when `-k` is given) |
 | `--cwd DIR` | Working directory for the debuggee |

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ It specifically supports modules
     - `threading` (with a thread inspector)
     - `multiprocessing` / `concurrent.futures` (with automatic child process attachment and a process inspector)
 
-- supports remote attachment to any debugpy-enabled Python program
+- supports remote attachment to debugpy-enabled Python programs
 
-- includes a JSON-RPC server mode for programmatic debug control, making it suitable for
+- includes a JSON-RPC server mode that enables programmatic debug control, making it suitable for
 automated, headless debugging workflows and AI-assisted debugging
 
 - can spawn the debuggee in an external terminal to enable debugging TUI applications
@@ -117,10 +117,20 @@ tdb --no-stop-on-entry my_program.py
 tdb --terminal xterm my_program.py
 
 # attach to a remote Python program that has a debugpy server on port 5678
-tdb -r remotehost:5678 my_program.py
+# (source code is automatically downloaded from the remote host)
+tdb -r remotehost:5678
 
-# prevent `argparse` confusion by separating `tdb` switches from
-# the debuggee switches by prefixing the debuggee with `--`
+# attach to a remote Python program that has a debugpy server on port 5678
+# and set a breakpoint where tdb and the remote program have the same
+# source code layout
+tdb -r remotehost:5678  -k my_program.py:42
+
+# attach to a remote Python program that has a debugpy server on port 5678
+# and set a breakpoint where code on the local host is at a different location
+# than code on the remote host
+tdb -r remotehost:5678 --local-root /my/code/dir --remote-root /app -k my_program.py:42
+
+# separate tdb arguments from debuggee arguments with `--` 
 tdb --python /path/to/venv/bin/python -- my_program.py -k 17 --max 23.3
 ```
 
@@ -134,7 +144,7 @@ python -m tdb my_program.py
 
 ```
 ┌─ Header ──────────────────────────────────────────────┐
-├─ Menu Bar (File | Configure | Help) ──────────────────┤
+├─ Menu Bar (File / Configure / Help)───────────────────┤
 │                           │                           │
 │   Code View               │  Console View (stdout)    │
 │   (source + breakpoints)  ├───────────────────────────┤
@@ -205,7 +215,7 @@ Switch from Navigate back to Debug mode with `Escape`.
 
 > **Note:** Many terminals send the byte sequence `ESC+f` for `Alt+F`, which Textual's
 ANSI parser rewrites to `Ctrl+Right` (the readline "forward-word" convention).
-`tdb` binds both so `Alt+F` works as expected regardless.
+`tdb` binds both so `Alt+F` works as expected.
 
 ### Debugging Controls
 
@@ -225,7 +235,8 @@ those for gdb/pdb, with some aliases and extras thrown in for convenience.
 | `G` | Go to last line (with count: `42G` jumps to line 42) |
 | `e` | Re-display the last error (traceback) |
 | `R` | Restart the debug session |
-| `Ctrl+Q` | Quit |
+| `q q` | Quit |
+| `Ctrl+q` | Quit |
 
 > **Note:** `f` ("finish") and `r` ("return") are both aliases for step-out. DAP's only
 "exit-a-function" primitive is `stepOut`, which runs the rest of the current function
@@ -246,7 +257,7 @@ print(results)   # next stop lands here, not on each sub-line above
 
 lands on `print(results)`, not on each interior sub-line of the `gather` call. Switch to
 **Line** mode (Configure > Step Mode) to get debugpy's native per-line behavior, which
-stops on each physical line — useful for inspecting how a complex expression is built up.
+stops on each physical line--useful for inspecting how a complex expression is built up.
 The choice is saved to `~/.config/tdb/config.json`.
 
 ### Breakpoints
@@ -272,6 +283,9 @@ Breakpoints persist across session restarts.
 The Variable View shows a tree of scopes (Locals, Globals) with all variables in the current
 frame. Expand nodes to drill into complex objects.  Children are loaded lazily on demand.
 Variable values can be changed in the Evaluate Console.
+
+Double-click a variable to display it in a modal.  This simplifies inspection of
+large or deeply nested data structures.
 
 ### Call Stack
 
@@ -306,8 +320,8 @@ The Console View captures stdout (normal text) and stderr (red text) from the de
 in real time.
 
 If your program prints a lot, or prompts for input, or uses colors or
-terminal control codes, consider running it in an external terminal
-with `--terminal` for the best experience.
+terminal control codes, run the program in an external terminal
+with `--terminal` for a better experience.
 
 ### Crash Detection
 
@@ -328,7 +342,6 @@ need to launch through `tdb` up front. Install the hook once at the top of your 
 ```python
 import sys
 import tdb
-
 sys.excepthook = tdb.exception_hook
 ```
 
@@ -346,11 +359,11 @@ In post-mortem mode you can:
 - Read the full traceback (including chained `cause`/`context` exceptions) in the Console View
 - Jump around the source with the full Code View (syntax highlighting, goto-line, etc.)
 
-Stepping, `continue`, breakpoints, restart, and Evaluate are disabled. The original
-interpreter is gone, the view is a frozen snapshot. Press `q` to exit.
+Stepping, continue, breakpoints, restart, and the Evaluate View are disabled. The original
+interpreter is gone since the view is a frozen snapshot. Press `q` to exit.
 
 The hook is a no-op when stdin/stdout aren't a tty (e.g. when your program is piped or
-run from cron), so it's safe to leave installed in production-style code. Snapshots are
+run from cron), so it is safe to leave installed in production code. Snapshots are
 written to a temp file that is deleted as soon as `tdb` exits.
 
 Snapshot depth / breadth is capped (5 levels, 50 children per container) to keep the
@@ -383,7 +396,7 @@ spawns `python -m tdb -r <port>` as a subprocess so the TUI takes over the termi
 and pauses the calling thread at the line that called `tdb.breakpoint()` (the hook
 auto-steps out of its own helper so you land in your own frame, not inside
 `breakpoint_hook.py`). Stepping (`n`/`s`/`o`), `continue`, and setting/removing breakpoints
-all work normally; quitting `tdb` (`Ctrl+Q`) detaches without killing the program, and
+all work normally; quitting `tdb` (`Ctrl+q`) detaches without killing the program, and
 debugpy auto-resumes any threads still paused.
 
 This differs from `tdb.exception_hook` in one way:
@@ -405,7 +418,8 @@ active tasks (updated each time the program stops). Click it to open a full-scre
   primitive (`Lock.acquire`, `Queue.get`, `asyncio.sleep`, …), and coroutine
 - **Right pane**: detail view with full stack trace and an expandable variable tree (same
 as the main Variables View) for the selected task
-- Press `g` to switch the right pane to the **wait graph** — a tree showing each blocked
+- Press `g` to switch the right pane to the **wait graph** which is a tree showing
+  each blocked
   task, the asyncio primitive it's parked on, and the task(s) holding that primitive.
   Cycles (deadlocks) are highlighted in red both in the task table and as a "Deadlock
   cycles" section at the top of the graph. Selecting a node in the tree highlights the
@@ -733,7 +747,7 @@ into) handle multi-line source statements:
 | Value | Behavior |
 |-------|----------|
 | `"statement"` (default) | A multi-line statement (e.g. a `gather(...)` call spanning five lines) is one step. The debugger keeps issuing DAP steps until execution leaves the statement, then stops on the next logical line. |
-| `"line"` | debugpy's native per-line behavior — stops on every physical line, including each interior sub-line of a multi-line expression. |
+| `"line"` | debugpy's native per-line behavior (stops on every physical line, including each interior sub-line of a multi-line expression)|
 
 Change it from the menu (**Configure > Step Mode**); the choice is saved immediately and
 applies to all future sessions. Breakpoint hits, exceptions, and pauses always interrupt

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,7 @@
-when the debuggee runs a debugpy service, it should not open tdb when the remote attachment ends
+remote attachment 
+
+# this works:  tdb -r PORT
+
+# this fails:  tdb -r PORT  file.py
+
+# need to be able to specify a file so that an additional breakpoint can be set

--- a/src/tdb/__init__.py
+++ b/src/tdb/__init__.py
@@ -1,6 +1,6 @@
 from tdb.breakpoint_hook import breakpoint
 from tdb.post_mortem import exception_hook
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = ["breakpoint", "exception_hook"]

--- a/src/tdb/app.py
+++ b/src/tdb/app.py
@@ -191,6 +191,7 @@ class TdbApp(_AppMessageRoutes, App):
         cli_breakpoints: list[tuple[str, int]] | None = None,
         attach_host: str | None = None,
         attach_port: int | None = None,
+        path_mappings: list[tuple[str, str]] | None = None,
         sub_process: bool = True,
         server_port: int | None = None,
         post_mortem_snapshot: dict | None = None,
@@ -210,6 +211,7 @@ class TdbApp(_AppMessageRoutes, App):
         self._cli_breakpoints = cli_breakpoints or []
         self._attach_host = attach_host
         self._attach_port = attach_port
+        self._path_mappings = path_mappings or []
         self._sub_process = sub_process
         self._server_port = server_port
         self._post_mortem_snapshot = post_mortem_snapshot
@@ -402,6 +404,7 @@ class TdbApp(_AppMessageRoutes, App):
                     await self.controller.remote_attach(
                         host=self._attach_host,
                         port=self._attach_port,
+                        path_mappings=self._path_mappings or None,
                     )
                 except OSError as exc:
                     # No server listening, route unreachable, DNS failure,

--- a/src/tdb/cli.py
+++ b/src/tdb/cli.py
@@ -272,9 +272,13 @@ def _parse_path_mappings(
         # Normalize remote: forward slashes, no trailing separator. Modern
         # Windows accepts forward slashes so we don't need posixpath vs
         # ntpath gymnastics — one normalized form covers both.
-        remote_norm = remote.replace("\\", "/").rstrip("/")
+        remote_norm = remote.replace("\\", "/").strip()
         if not remote_norm:
-            parser.error(f"--remote-root cannot be empty or root: {remote}")
+            parser.error(f"--remote-root cannot be empty: {remote}")
+        if remote_norm != "/":
+            remote_norm = remote_norm.rstrip("/")
+            if not remote_norm:
+                remote_norm = "/"
         pairs.append((str(local_path), remote_norm))
     args.path_mappings = pairs
 

--- a/src/tdb/cli.py
+++ b/src/tdb/cli.py
@@ -276,10 +276,19 @@ def _parse_path_mappings(
         if not remote_norm:
             parser.error(f"--remote-root cannot be empty: {remote}")
         if remote_norm != "/":
+            had_trailing = remote_norm.endswith("/")
             remote_norm = remote_norm.rstrip("/")
+            # Preserve Windows drive root (e.g. "C:/") — stripping the slash
+            # would change semantics to drive-relative "C:".
+            if (
+                had_trailing
+                and len(remote_norm) == 2
+                and remote_norm[0].isalpha()
+                and remote_norm[1] == ":"
+            ):
+                remote_norm += "/"
             if not remote_norm:
                 remote_norm = "/"
-        pairs.append((str(local_path), remote_norm))
     args.path_mappings = pairs
 
 

--- a/src/tdb/cli.py
+++ b/src/tdb/cli.py
@@ -287,8 +287,10 @@ def _parse_path_mappings(
                 and remote_norm[1] == ":"
             ):
                 remote_norm += "/"
+            # All-slashes input (e.g. "///") rstrips to empty → treat as "/".
             if not remote_norm:
                 remote_norm = "/"
+        pairs.append((str(local_path), remote_norm))
     args.path_mappings = pairs
 
 

--- a/src/tdb/cli.py
+++ b/src/tdb/cli.py
@@ -346,7 +346,8 @@ def _parse_breakpoints(
                         f"Breakpoint file not found: {file_part} "
                         f"(searched: cwd, {roots_str})"
                     )
-                parser.error(f"Breakpoint file not found: {file_part}")
+                else:
+                    parser.error(f"Breakpoint file not found: {file_part}")
             parsed_bps.append((str(bp_path), line))
         else:
             try:

--- a/src/tdb/cli.py
+++ b/src/tdb/cli.py
@@ -411,6 +411,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     _validate_terminal_choice(args, parser)
     _parse_attach_spec(args, parser)
+    if args.headless and args.remote_attach:
+        parser.error("--headless does not currently support --remote-attach")
     _parse_path_mappings(args, parser)
     _resolve_program_path(args, parser)
     _parse_breakpoints(args, parser)

--- a/src/tdb/cli.py
+++ b/src/tdb/cli.py
@@ -111,6 +111,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run debuggee in the named external terminal (for TUI programs)",
     )
     parser.add_argument(
+        "--local-root",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Local directory containing a copy of code from the remote "
+        "debuggee. Pair with --remote-root: each --local-root is zipped "
+        "in CLI order with the matching --remote-root, so the two flags "
+        "must be supplied in equal numbers. Used for remote-attach mode "
+        "(-r); debugpy translates paths bidirectionally so tdb reads "
+        "local files instead of requesting source over DAP.",
+    )
+    parser.add_argument(
+        "--remote-root",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Remote directory matched to --local-root. Must appear the "
+        "same number of times as --local-root; pairs are taken in CLI "
+        "order via zip().",
+    )
+    parser.add_argument(
         "--server",
         action="store_true",
         help="Start JSON-RPC debug server alongside the TUI",
@@ -218,6 +239,46 @@ def _parse_attach_spec(
         parser.error(f"Invalid port in --remote-attach: {spec}")
 
 
+def _parse_path_mappings(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+) -> None:
+    """Pair --local-root with --remote-root via zip(), validate counts/usage.
+
+    Stores `args.path_mappings` as `list[tuple[local, remote]]` (or empty).
+    --remote-attach is required when either flag is used; counts must match.
+    Local roots must be existing directories; remote roots are normalized
+    (trailing-separator stripped) but otherwise opaque since they live on
+    the debuggee's machine.
+    """
+    args.path_mappings = []
+    locals_ = args.local_root or []
+    remotes = args.remote_root or []
+    if not locals_ and not remotes:
+        return
+    if not args.remote_attach:
+        parser.error("--local-root / --remote-root require --remote-attach")
+    if len(locals_) != len(remotes):
+        parser.error(
+            f"--local-root and --remote-root must be supplied in equal "
+            f"numbers (got {len(locals_)} local, {len(remotes)} remote); "
+            f"each pair is matched in CLI order"
+        )
+    pairs: list[tuple[str, str]] = []
+    for local, remote in zip(locals_, remotes):
+        local_path = Path(local).resolve()
+        if not local_path.is_dir():
+            parser.error(f"--local-root not a directory: {local}")
+        # Normalize remote: forward slashes, no trailing separator. Modern
+        # Windows accepts forward slashes so we don't need posixpath vs
+        # ntpath gymnastics — one normalized form covers both.
+        remote_norm = remote.replace("\\", "/").rstrip("/")
+        if not remote_norm:
+            parser.error(f"--remote-root cannot be empty or root: {remote}")
+        pairs.append((str(local_path), remote_norm))
+    args.path_mappings = pairs
+
+
 def _resolve_program_path(
     args: argparse.Namespace,
     parser: argparse.ArgumentParser,
@@ -237,6 +298,26 @@ def _resolve_program_path(
         args.program = str(program_path)
 
 
+def _resolve_breakpoint_file(file_part: str, local_roots: list[str]) -> Path | None:
+    """Find a `-k FILE:LINE` file on disk.
+
+    Absolute or cwd-relative paths resolve directly. If those don't
+    exist and `--local-root` directories were given, search each one
+    in CLI order; first match wins. Returns None if nothing matches —
+    caller turns that into a parser.error with the search path.
+    """
+    direct = Path(file_part).resolve()
+    if direct.is_file():
+        return direct
+    if Path(file_part).is_absolute():
+        return None
+    for root in local_roots:
+        candidate = Path(root) / file_part
+        if candidate.is_file():
+            return candidate.resolve()
+    return None
+
+
 def _parse_breakpoints(
     args: argparse.Namespace,
     parser: argparse.ArgumentParser,
@@ -249,6 +330,7 @@ def _parse_breakpoints(
     statement starts.
     """
     parsed_bps: list[tuple[str, int]] = []
+    local_roots = [local for local, _ in args.path_mappings]
     for spec in args.breakpoint:
         if ":" in spec:
             file_part, line_part = spec.rsplit(":", 1)
@@ -256,8 +338,14 @@ def _parse_breakpoints(
                 line = int(line_part)
             except ValueError:
                 parser.error(f"Invalid line number in breakpoint: {spec}")
-            bp_path = Path(file_part).resolve()
-            if not bp_path.is_file():
+            bp_path = _resolve_breakpoint_file(file_part, local_roots)
+            if bp_path is None:
+                if local_roots:
+                    roots_str = ", ".join(local_roots)
+                    parser.error(
+                        f"Breakpoint file not found: {file_part} "
+                        f"(searched: cwd, {roots_str})"
+                    )
                 parser.error(f"Breakpoint file not found: {file_part}")
             parsed_bps.append((str(bp_path), line))
         else:
@@ -318,6 +406,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     _validate_terminal_choice(args, parser)
     _parse_attach_spec(args, parser)
+    _parse_path_mappings(args, parser)
     _resolve_program_path(args, parser)
     _parse_breakpoints(args, parser)
     _snap_breakpoints(args)
@@ -484,6 +573,7 @@ def _run_tui(args: argparse.Namespace) -> None:
         cli_breakpoints=args.breakpoint,
         attach_host=args.attach_host,
         attach_port=args.attach_port,
+        path_mappings=args.path_mappings,
         sub_process=not args.no_subprocess,
         server_port=args.server_port if args.server else None,
     )

--- a/src/tdb/dap/client.py
+++ b/src/tdb/dap/client.py
@@ -313,6 +313,7 @@ class DAPClient:
         port: int = 0,
         sub_process_id: int | None = None,
         just_my_code: bool = True,
+        path_mappings: list[tuple[str, str]] | None = None,
     ) -> asyncio.Future[Response]:
         """Send attach request. Returns a Future (same pattern as launch).
 
@@ -323,6 +324,11 @@ class DAPClient:
         when start_reason == "launch"). To stop the debuggee at the
         first statement after attach, send a `pause` request before
         `configurationDone` — see controller.do_configure.
+
+        `path_mappings` is a list of `(local_root, remote_root)` pairs;
+        debugpy translates paths bidirectionally so the tdb host can
+        read local copies of remote source files instead of fetching
+        them via DAP `source` requests.
         """
         arguments: dict[str, Any] = {
             "type": "debugpy",
@@ -333,6 +339,11 @@ class DAPClient:
         }
         if sub_process_id is not None:
             arguments["subProcessId"] = sub_process_id
+        if path_mappings:
+            arguments["pathMappings"] = [
+                {"localRoot": local, "remoteRoot": remote}
+                for local, remote in path_mappings
+            ]
         return await self._send_raw("attach", arguments)
 
     async def configuration_done(self) -> None:

--- a/src/tdb/session/controller.py
+++ b/src/tdb/session/controller.py
@@ -211,7 +211,12 @@ class DebugController:
             sub_process=p["sub_process"],
         )
 
-    async def remote_attach(self, host: str, port: int) -> None:
+    async def remote_attach(
+        self,
+        host: str,
+        port: int,
+        path_mappings: list[tuple[str, str]] | None = None,
+    ) -> None:
         """Attach to a remote debugpy server listening on host:port.
 
         DAP sequence (same as launch, but with attach instead):
@@ -221,6 +226,9 @@ class DebugController:
         4. debugpy sends 'initialized' event
         5. on_dap_initialized handler sends breakpoints + configurationDone
         6. debugpy sends attach response
+
+        `path_mappings` is forwarded to debugpy's `pathMappings` attach
+        arg — see `dap/client.py::attach`.
         """
         self._setup_event_handlers()
         self._launch_params = {}
@@ -229,7 +237,11 @@ class DebugController:
         await self.client.connect(host, port)
         await self.client.initialize()
 
-        self._launch_future = await self.client.attach(host=host, port=port)
+        self._launch_future = await self.client.attach(
+            host=host,
+            port=port,
+            path_mappings=path_mappings,
+        )
 
     async def do_configure(self) -> None:
         """Called after 'initialized' event. Sends breakpoints + configurationDone.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -257,3 +257,215 @@ def test_doc_text_renders_to_stdout(capsys):
     assert "textual-debugger" in out
     # And tables in the README produce box-drawing characters.
     assert "─" in out or "━" in out
+
+
+# --- --local-root / --remote-root path mappings -----------------------------
+
+
+def test_path_mappings_default_empty():
+    args = parse_args(["-r", "5678"])
+    assert args.path_mappings == []
+
+
+def test_path_mappings_single_pair(tmp_path):
+    local = tmp_path / "code"
+    local.mkdir()
+    args = parse_args(
+        ["-r", "5678", "--local-root", str(local), "--remote-root", "/srv/code"]
+    )
+    assert args.path_mappings == [(str(local.resolve()), "/srv/code")]
+
+
+def test_path_mappings_multiple_pairs_zip_in_order(tmp_path):
+    a = tmp_path / "a"
+    a.mkdir()
+    b = tmp_path / "b"
+    b.mkdir()
+    args = parse_args(
+        [
+            "-r",
+            "5678",
+            "--local-root",
+            str(a),
+            "--remote-root",
+            "/srv/A",
+            "--local-root",
+            str(b),
+            "--remote-root",
+            "/srv/B",
+        ]
+    )
+    assert args.path_mappings == [
+        (str(a.resolve()), "/srv/A"),
+        (str(b.resolve()), "/srv/B"),
+    ]
+
+
+def test_path_mappings_count_mismatch_errors(tmp_path):
+    local = tmp_path / "code"
+    local.mkdir()
+    with pytest.raises(SystemExit):
+        parse_args(
+            [
+                "-r",
+                "5678",
+                "--local-root",
+                str(local),
+                "--remote-root",
+                "/srv/A",
+                "--remote-root",
+                "/srv/B",
+            ]
+        )
+
+
+def test_path_mappings_require_remote_attach(tmp_path):
+    prog = tmp_path / "x.py"
+    prog.write_text("\n")
+    local = tmp_path / "code"
+    local.mkdir()
+    with pytest.raises(SystemExit):
+        parse_args(
+            [
+                str(prog),
+                "--local-root",
+                str(local),
+                "--remote-root",
+                "/srv/A",
+            ]
+        )
+
+
+def test_path_mappings_local_root_must_be_directory(tmp_path):
+    not_a_dir = tmp_path / "nope.py"
+    not_a_dir.write_text("\n")
+    with pytest.raises(SystemExit):
+        parse_args(
+            [
+                "-r",
+                "5678",
+                "--local-root",
+                str(not_a_dir),
+                "--remote-root",
+                "/srv/A",
+            ]
+        )
+
+
+def test_path_mappings_remote_root_normalized(tmp_path):
+    local = tmp_path / "code"
+    local.mkdir()
+    # Trailing slash + backslashes both normalize to clean forward-slash form.
+    args = parse_args(
+        [
+            "-r",
+            "5678",
+            "--local-root",
+            str(local),
+            "--remote-root",
+            r"C:\srv\code\\",
+        ]
+    )
+    assert args.path_mappings == [(str(local.resolve()), "C:/srv/code")]
+
+
+def test_breakpoint_relative_path_resolved_under_local_root(tmp_path):
+    local = tmp_path / "code"
+    local.mkdir()
+    src = local / "program.py"
+    src.write_text("\n" * 20)
+    args = parse_args(
+        [
+            "-r",
+            "5678",
+            "--local-root",
+            str(local),
+            "--remote-root",
+            "/srv/code",
+            "-k",
+            "program.py:5",
+        ]
+    )
+    # Resolved to the local-root copy; snap_breakpoint may move the line
+    # to the nearest statement (blank file → likely dropped, so only
+    # assert path-resolution here by inspecting before-snap state).
+    # Use a real statement so snap_breakpoint keeps it:
+    src.write_text("x = 1\n" * 20)
+    args = parse_args(
+        [
+            "-r",
+            "5678",
+            "--local-root",
+            str(local),
+            "--remote-root",
+            "/srv/code",
+            "-k",
+            "program.py:5",
+        ]
+    )
+    assert args.breakpoint == [(str(src.resolve()), 5)]
+
+
+def test_breakpoint_relative_path_not_found_under_local_root_errors(tmp_path):
+    local = tmp_path / "code"
+    local.mkdir()
+    with pytest.raises(SystemExit):
+        parse_args(
+            [
+                "-r",
+                "5678",
+                "--local-root",
+                str(local),
+                "--remote-root",
+                "/srv/code",
+                "-k",
+                "nope.py:5",
+            ]
+        )
+
+
+def test_breakpoint_absolute_path_still_works_with_local_root(tmp_path):
+    local = tmp_path / "code"
+    local.mkdir()
+    elsewhere = tmp_path / "elsewhere.py"
+    elsewhere.write_text("x = 1\n" * 20)
+    args = parse_args(
+        [
+            "-r",
+            "5678",
+            "--local-root",
+            str(local),
+            "--remote-root",
+            "/srv/code",
+            "-k",
+            f"{elsewhere}:5",
+        ]
+    )
+    assert args.breakpoint == [(str(elsewhere.resolve()), 5)]
+
+
+def test_breakpoint_relative_searches_local_roots_in_order(tmp_path):
+    a = tmp_path / "a"
+    a.mkdir()
+    b = tmp_path / "b"
+    b.mkdir()
+    # Only the second local-root has the file.
+    src = b / "found.py"
+    src.write_text("x = 1\n" * 20)
+    args = parse_args(
+        [
+            "-r",
+            "5678",
+            "--local-root",
+            str(a),
+            "--remote-root",
+            "/srv/A",
+            "--local-root",
+            str(b),
+            "--remote-root",
+            "/srv/B",
+            "-k",
+            "found.py:5",
+        ]
+    )
+    assert args.breakpoint == [(str(src.resolve()), 5)]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -373,23 +373,7 @@ def test_breakpoint_relative_path_resolved_under_local_root(tmp_path):
     local = tmp_path / "code"
     local.mkdir()
     src = local / "program.py"
-    src.write_text("\n" * 20)
-    args = parse_args(
-        [
-            "-r",
-            "5678",
-            "--local-root",
-            str(local),
-            "--remote-root",
-            "/srv/code",
-            "-k",
-            "program.py:5",
-        ]
-    )
-    # Resolved to the local-root copy; snap_breakpoint may move the line
-    # to the nearest statement (blank file → likely dropped, so only
-    # assert path-resolution here by inspecting before-snap state).
-    # Use a real statement so snap_breakpoint keeps it:
+    # Use a real statement so snap_breakpoint keeps the breakpoint (and avoid warnings).
     src.write_text("x = 1\n" * 20)
     args = parse_args(
         [

--- a/tests/unit/test_dap_attach_pathmappings.py
+++ b/tests/unit/test_dap_attach_pathmappings.py
@@ -1,0 +1,67 @@
+"""Unit tests for DAPClient.attach pathMappings serialization.
+
+`--local-root` / `--remote-root` are paired in CLI order and threaded
+through `controller.remote_attach` → `client.attach(path_mappings=...)`.
+debugpy expects the wire shape `[{"localRoot": L, "remoteRoot": R}, ...]`
+in the attach arguments; this file pins that contract.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tdb.dap.client import DAPClient
+
+
+@pytest.mark.asyncio
+async def test_attach_omits_path_mappings_when_none():
+    client = DAPClient()
+    client._send_raw = AsyncMock(return_value=None)
+    await client.attach(host="1.2.3.4", port=5678)
+    args = client._send_raw.await_args[0][1]
+    assert "pathMappings" not in args
+
+
+@pytest.mark.asyncio
+async def test_attach_omits_path_mappings_when_empty_list():
+    client = DAPClient()
+    client._send_raw = AsyncMock(return_value=None)
+    await client.attach(host="1.2.3.4", port=5678, path_mappings=[])
+    args = client._send_raw.await_args[0][1]
+    assert "pathMappings" not in args
+
+
+@pytest.mark.asyncio
+async def test_attach_emits_single_path_mapping():
+    client = DAPClient()
+    client._send_raw = AsyncMock(return_value=None)
+    await client.attach(
+        host="1.2.3.4",
+        port=5678,
+        path_mappings=[("/local/code", "/srv/code")],
+    )
+    args = client._send_raw.await_args[0][1]
+    assert args["pathMappings"] == [
+        {"localRoot": "/local/code", "remoteRoot": "/srv/code"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_attach_emits_multiple_path_mappings_in_order():
+    client = DAPClient()
+    client._send_raw = AsyncMock(return_value=None)
+    await client.attach(
+        host="1.2.3.4",
+        port=5678,
+        path_mappings=[
+            ("/local/a", "/srv/A"),
+            ("/local/b", "/srv/B"),
+        ],
+    )
+    args = client._send_raw.await_args[0][1]
+    assert args["pathMappings"] == [
+        {"localRoot": "/local/a", "remoteRoot": "/srv/A"},
+        {"localRoot": "/local/b", "remoteRoot": "/srv/B"},
+    ]


### PR DESCRIPTION
Needed for remote attachment when tdb is given a breakpoint but it and the remote program have code in different directories.