### PR TITLE
merge TUI and JSON-RPC inspection mechanisms

### DIFF
--- a/src/tdb/app_handlers/inspection.py
+++ b/src/tdb/app_handlers/inspection.py
@@ -20,18 +20,11 @@ from __future__ import annotations
 import logging
 import os
 import re
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from tdb.dap.types import Source, StackFrame
-from tdb.inspection import (
-    PROCESS_COLLECT_EXPR,
-    ProcessInfo,
-    TASK_COLLECT_EXPR,
-    TASK_LOCALS_EXPR,
-    parse_process_json,
-    parse_task_json,
-)
+from tdb.inspection import ProcessInfo
+from tdb.session.inspect_service import InspectService, SessionGateError
 from tdb.widgets.async_tasks_modal import AsyncTasksModal
 from tdb.widgets.menu_bar import MenuBar
 from tdb.widgets.processes_modal import ProcessesModal
@@ -48,10 +41,17 @@ log = logging.getLogger(__name__)
 
 
 class InspectionWorkflows:
-    """Drives the threads/processes/async-tasks UI flows."""
+    """Drives the threads/processes/async-tasks UI flows.
+
+    Fetch-and-parse mechanics live in `tdb.session.inspect_service.
+    InspectService` (shared with the JSON-RPC server); this collaborator
+    holds only the TUI presentation around them — gates rendered as
+    toasts, modal lifecycle, menu-bar labels.
+    """
 
     def __init__(self, app: TdbApp) -> None:
         self.app = app
+        self._svc = InspectService(lambda: self.app.controller)
 
     # --- Async tasks ----------------------------------------------------
 
@@ -82,19 +82,15 @@ class InspectionWorkflows:
         if ctrl.state.is_running:
             self.app.notify("Program is running — pause first", title="Async Tasks")
             return
-        raw = ""
         try:
-            raw = await ctrl.evaluate(TASK_COLLECT_EXPR)
-            tasks = parse_task_json(raw)
+            tasks = await self._svc.collect_tasks()
+        except SessionGateError:
+            return  # phase changed between our gate and the fetch
         except Exception:
             log.exception("Error fetching async tasks")
             tasks = []
 
         if not tasks:
-            log.warning(
-                "Async task collection returned no tasks. Raw: %s",
-                raw[:300] if raw else "(empty)",
-            )
             self.app.notify(
                 "No asyncio tasks found (program may not use asyncio)",
                 title="Async Tasks",
@@ -110,12 +106,10 @@ class InspectionWorkflows:
         self.app.panels.async_tasks = None
 
     async def refresh_async_tasks(self) -> None:
-        ctrl = self.app.controller
-        if ctrl.state.is_terminated or ctrl.state.is_running:
-            return
         try:
-            raw = await ctrl.evaluate(TASK_COLLECT_EXPR)
-            tasks = parse_task_json(raw)
+            tasks = await self._svc.collect_tasks()
+        except SessionGateError:
+            return
         except Exception:
             log.exception("Error refreshing async tasks")
             return
@@ -124,29 +118,15 @@ class InspectionWorkflows:
 
     async def load_task_variables(self, task_name: str) -> None:
         """Fetch a task's local variables via DAP and populate the tree."""
-        ctrl = self.app.controller
-        if ctrl.state.is_terminated or ctrl.state.is_running:
-            return
         modal = self.app.panels.async_tasks
         if modal is None:
             return
-        variables: list = []
         try:
-            expr = TASK_LOCALS_EXPR.format(task_name=task_name)
-            # Route around synthetic frame ids — see
-            # controller.resolve_evaluate_frame_id. Without this, after
-            # the user has navigated to a task once, state.current_frame_id
-            # is negative and debugpy rejects the evaluate request.
-            frame_id = await ctrl.resolve_evaluate_frame_id(ctrl.active_client)
-            _result, var_ref = await ctrl.active_client.evaluate(
-                expr,
-                frame_id=frame_id,
-                context="repl",
-            )
-            if var_ref > 0:
-                variables = await ctrl.active_client.variables(var_ref)
-        except Exception:
-            log.debug("Failed to load variables for task %s", task_name)
+            # Routes around synthetic frame ids and evaluates against the
+            # active client — see InspectService.task_locals.
+            variables = await self._svc.task_locals(task_name)
+        except SessionGateError:
+            return
         modal.show_task_variables(variables)
 
     def navigate_to_task(self, task_name: str) -> bool:
@@ -213,7 +193,9 @@ class InspectionWorkflows:
             self.app.notify("Program is running — pause first", title="Threads")
             return
         try:
-            threads = await ctrl.client.threads()
+            threads = await self._svc.list_threads()
+        except SessionGateError:
+            return
         except Exception:
             log.exception("Error fetching threads")
             self.app.notify("Failed to fetch threads", title="Threads")
@@ -230,29 +212,16 @@ class InspectionWorkflows:
 
     async def load_thread_detail(self, thread_id: int) -> None:
         """Fetch stack trace and variables for a thread."""
-        ctrl = self.app.controller
-        if ctrl.state.is_terminated or ctrl.state.is_running:
-            return
         modal = self.app.panels.threads
         if modal is None:
             return
         try:
-            frames = await ctrl.client.stack_trace(thread_id)
+            frames, scopes, variables = await self._svc.thread_stack(thread_id)
+        except SessionGateError:
+            return
         except Exception:
             log.debug("Failed to fetch stack trace for thread %d", thread_id)
-            frames = []
-        scopes: list = []
-        variables: dict = {}
-        if frames:
-            top_frame = frames[0]
-            try:
-                scopes = await ctrl.client.scopes(top_frame.id)
-                for scope in scopes:
-                    variables[scope.variables_reference] = await ctrl.client.variables(
-                        scope.variables_reference
-                    )
-            except Exception:
-                log.debug("Failed to fetch variables for thread %d", thread_id)
+            frames, scopes, variables = [], [], {}
         modal.show_thread_detail(thread_id, frames, scopes, variables)
 
     # --- Full-Contents (variable subtree pre-fetch) --------------------
@@ -315,55 +284,17 @@ class InspectionWorkflows:
 
     # --- Processes ------------------------------------------------------
 
-    def get_processes_from_pids(self) -> list[ProcessInfo]:
-        """Build ProcessInfo list from tracked child PIDs via /proc.
-
-        Linux-only fallback used when DAP `evaluate` against the parent
-        is unavailable (e.g., the parent isn't the active process).
-        """
-        result = []
-        for pid in self.app.controller.get_child_pids():
-            try:
-                cmdline_path = Path(f"/proc/{pid}/cmdline")
-                if not cmdline_path.exists():
-                    continue
-                cmdline = (
-                    cmdline_path.read_bytes().replace(b"\x00", b" ").decode().strip()
-                )
-                status_path = Path(f"/proc/{pid}/status")
-                name = f"Process-{pid}"
-                if status_path.exists():
-                    for line in status_path.read_text().splitlines():
-                        if line.startswith("Name:"):
-                            name = line.split(":", 1)[1].strip()
-                            break
-                result.append(
-                    ProcessInfo(
-                        name=name,
-                        pid=pid,
-                        alive=True,
-                        exitcode=None,
-                        daemon=False,
-                        target=cmdline[:200] if cmdline else "unknown",
-                        args="()",
-                        kwargs="{}",
-                        start_method="",
-                    )
-                )
-            except Exception:
-                pass
-        return result
-
     async def get_processes(self) -> list[ProcessInfo]:
-        """Get child process info, trying eval on parent first, then /proc."""
+        """Get child process info, trying eval on parent first, then /proc.
+
+        Maps a gate failure (phase changed mid-flight) to an empty list:
+        callers treat "nothing to show" and "can't look right now" the
+        same way.
+        """
         try:
-            raw = await self.app.controller.evaluate_on_parent(PROCESS_COLLECT_EXPR)
-            processes = parse_process_json(raw)
-            if processes:
-                return processes
-        except Exception:
-            pass
-        return self.get_processes_from_pids()
+            return await self._svc.collect_processes()
+        except SessionGateError:
+            return []
 
     async def fetch_process_count(self) -> None:
         """Update the Processes label with child process count."""
@@ -470,25 +401,10 @@ class InspectionWorkflows:
         modal = self.app.panels.processes
         if modal is None:
             return
-        child = self.app.controller.get_child_client(pid)
-        if child is None:
+        detail = await self._svc.process_stack(pid)
+        if detail is None:
             # PIDs from /proc might not exactly match the controller's keys
             modal.show_process_detail(pid, [], [], {})
             return
-        frames: list = []
-        scopes: list = []
-        variables: dict = {}
-        try:
-            threads = await child.threads()
-            if threads:
-                frames = await child.stack_trace(threads[0].id)
-                if frames:
-                    top_frame = frames[0]
-                    scopes = await child.scopes(top_frame.id)
-                    for scope in scopes:
-                        variables[scope.variables_reference] = await child.variables(
-                            scope.variables_reference
-                        )
-        except Exception:
-            log.debug("Failed to fetch detail for child process %d", pid)
+        frames, scopes, variables = detail
         modal.show_process_detail(pid, frames, scopes, variables)

--- a/src/tdb/server/handlers.py
+++ b/src/tdb/server/handlers.py
@@ -546,8 +546,15 @@ class RpcHandlers:
         # Shared with the TUI's task-variables flow: evaluates against
         # the active client (parent or child) with a real frame id —
         # synthetic (negative) frame ids from task navigation are routed
-        # around inside the service.
-        variables = await self._inspect.task_locals(target_name)
+        # around inside the service. The service re-gates on entry, so a
+        # phase change between collect_tasks above and this call (e.g. a
+        # `terminated` event landing mid-action) raises SessionGateError
+        # here too — map it like the initial gate rather than letting it
+        # escape to the dispatcher's generic handler.
+        try:
+            variables = await self._inspect.task_locals(target_name)
+        except SessionGateError as e:
+            return self._gate_error(e, "inspect tasks")
         if variables:
             for v in variables:
                 type_str = f" ({v.type})" if v.type else ""
@@ -640,24 +647,30 @@ class RpcHandlers:
         ]
         try:
             frames, scopes, variables = await self._inspect.thread_stack(thread_id)
-            if frames:
-                for i, frame in enumerate(frames):
-                    src = (
-                        frame.source.path
-                        if frame.source and frame.source.path
-                        else "<unknown>"
-                    )
-                    lines.append(f"  #{i} {frame.name} at {src}:{frame.line}")
-                lines.append("")
-                lines.append("Variables:")
-                for scope in scopes:
-                    for v in variables.get(scope.variables_reference, []):
-                        type_str = f" ({v.type})" if v.type else ""
-                        lines.append(f"  {v.name}{type_str} = {v.value}")
-            else:
-                lines.append("  (no stack frames)")
+        except SessionGateError as e:
+            # Phase changed between list_threads above and the stack
+            # fetch — report it as the gate condition it is, not as a
+            # stack-trace failure.
+            return self._gate_error(e, "inspect threads")
         except Exception:
             lines.append("  (failed to fetch stack trace)")
+            return RpcResponse.ok("\n".join(lines))
+        if frames:
+            for i, frame in enumerate(frames):
+                src = (
+                    frame.source.path
+                    if frame.source and frame.source.path
+                    else "<unknown>"
+                )
+                lines.append(f"  #{i} {frame.name} at {src}:{frame.line}")
+            lines.append("")
+            lines.append("Variables:")
+            for scope in scopes:
+                for v in variables.get(scope.variables_reference, []):
+                    type_str = f" ({v.type})" if v.type else ""
+                    lines.append(f"  {v.name}{type_str} = {v.value}")
+        else:
+            lines.append("  (no stack frames)")
         return RpcResponse.ok("\n".join(lines))
 
     async def action_list_processes(self, params: list[Any]) -> RpcResponse:

--- a/src/tdb/server/handlers.py
+++ b/src/tdb/server/handlers.py
@@ -19,15 +19,11 @@ from pathlib import Path
 from typing import Any, Callable
 
 from tdb.inspection import (
-    PROCESS_COLLECT_EXPR,
-    TASK_COLLECT_EXPR,
-    TASK_LOCALS_EXPR,
     build_wait_graph,
     find_cycles,
-    parse_process_json,
-    parse_task_json,
 )
 from tdb.session.controller import DebugController
+from tdb.session.inspect_service import InspectService, SessionGateError
 from .event_handler import ServerEventHandler
 from .rpc_types import RpcResponse
 
@@ -165,6 +161,17 @@ class RpcHandlers:
             self._handler_ref = event_handler
         else:
             self._handler_ref = HandlerRef(event_handler)
+        # Shared fetch-and-parse workflows (tasks / threads / processes),
+        # common with the TUI's InspectionWorkflows. Reads the controller
+        # through the ref so it follows restart swaps.
+        self._inspect = InspectService(lambda: self._controller_ref.ctrl)
+
+    @staticmethod
+    def _gate_error(e: SessionGateError, doing: str) -> RpcResponse:
+        """Map a SessionGateError onto this API's established wording."""
+        if e.reason == "terminated":
+            return RpcResponse.error("Program has terminated")
+        return RpcResponse.error(f"Cannot {doing} while program is running")
 
     # --- Convenience accessors ------------------------------------------
 
@@ -477,13 +484,10 @@ class RpcHandlers:
         return RpcResponse.ok(text)
 
     async def action_list_tasks(self, params: list[Any]) -> RpcResponse:
-        if self.controller.state.is_running:
-            return RpcResponse.error("Cannot list tasks while program is running")
-        if self.controller.state.is_terminated:
-            return RpcResponse.error("Program has terminated")
         try:
-            raw = await self.controller.evaluate(TASK_COLLECT_EXPR)
-            tasks = parse_task_json(raw)
+            tasks = await self._inspect.collect_tasks()
+        except SessionGateError as e:
+            return self._gate_error(e, "list tasks")
         except Exception as e:
             return RpcResponse.error(f"Failed to collect tasks: {e}")
         if not tasks:
@@ -502,14 +506,11 @@ class RpcHandlers:
     async def action_inspect_task(self, params: list[Any]) -> RpcResponse:
         if not params:
             return RpcResponse.error("params[0] must be a task name")
-        if self.controller.state.is_running:
-            return RpcResponse.error("Cannot inspect tasks while program is running")
-        if self.controller.state.is_terminated:
-            return RpcResponse.error("Program has terminated")
         target_name = str(params[0])
         try:
-            raw = await self.controller.evaluate(TASK_COLLECT_EXPR)
-            tasks = parse_task_json(raw)
+            tasks = await self._inspect.collect_tasks()
+        except SessionGateError as e:
+            return self._gate_error(e, "inspect tasks")
         except Exception as e:
             return RpcResponse.error(f"Failed to collect tasks: {e}")
         task = next((t for t in tasks if t.name == target_name), None)
@@ -542,39 +543,24 @@ class RpcHandlers:
             lines.append("  (no stack frames — task may be awaiting)")
         lines.append("")
         lines.append("Variables:")
-        try:
-            expr = TASK_LOCALS_EXPR.format(task_name=target_name)
-            # Skip synthetic (negative) frame ids installed by the TUI
-            # task-navigation feature — they aren't valid for DAP evaluate.
-            frame_id = await self.controller.resolve_evaluate_frame_id(
-                self.controller.client,
-            )
-            _result, var_ref = await self.controller.client.evaluate(
-                expr,
-                frame_id=frame_id,
-                context="repl",
-            )
-            if var_ref > 0:
-                variables = await self.controller.client.variables(var_ref)
-                for v in variables:
-                    type_str = f" ({v.type})" if v.type else ""
-                    lines.append(f"  {v.name}{type_str} = {v.value}")
-            else:
-                lines.append("  (no variables — frame not available)")
-        except Exception:
+        # Shared with the TUI's task-variables flow: evaluates against
+        # the active client (parent or child) with a real frame id —
+        # synthetic (negative) frame ids from task navigation are routed
+        # around inside the service.
+        variables = await self._inspect.task_locals(target_name)
+        if variables:
+            for v in variables:
+                type_str = f" ({v.type})" if v.type else ""
+                lines.append(f"  {v.name}{type_str} = {v.value}")
+        else:
             lines.append("  (no variables — frame not available)")
         return RpcResponse.ok("\n".join(lines))
 
     async def action_wait_graph(self, params: list[Any]) -> RpcResponse:
-        if self.controller.state.is_running:
-            return RpcResponse.error(
-                "Cannot compute wait graph while program is running"
-            )
-        if self.controller.state.is_terminated:
-            return RpcResponse.error("Program has terminated")
         try:
-            raw = await self.controller.evaluate(TASK_COLLECT_EXPR)
-            tasks = parse_task_json(raw)
+            tasks = await self._inspect.collect_tasks()
+        except SessionGateError as e:
+            return self._gate_error(e, "compute wait graph")
         except Exception as e:
             return RpcResponse.error(f"Failed to collect tasks: {e}")
         if not tasks:
@@ -612,12 +598,10 @@ class RpcHandlers:
         return RpcResponse.ok("\n".join(lines).rstrip())
 
     async def action_list_threads(self, params: list[Any]) -> RpcResponse:
-        if self.controller.state.is_running:
-            return RpcResponse.error("Cannot list threads while program is running")
-        if self.controller.state.is_terminated:
-            return RpcResponse.error("Program has terminated")
         try:
-            threads = await self.controller.client.threads()
+            threads = await self._inspect.list_threads()
+        except SessionGateError as e:
+            return self._gate_error(e, "list threads")
         except Exception as e:
             return RpcResponse.error(f"Failed to fetch threads: {e}")
         if not threads:
@@ -632,16 +616,14 @@ class RpcHandlers:
     async def action_inspect_thread(self, params: list[Any]) -> RpcResponse:
         if not params:
             return RpcResponse.error("params[0] must be a thread ID")
-        if self.controller.state.is_running:
-            return RpcResponse.error("Cannot inspect threads while program is running")
-        if self.controller.state.is_terminated:
-            return RpcResponse.error("Program has terminated")
         try:
             thread_id = int(params[0])
         except (ValueError, TypeError):
             return RpcResponse.error(f"Invalid thread ID: {params[0]}")
         try:
-            threads = await self.controller.client.threads()
+            threads = await self._inspect.list_threads()
+        except SessionGateError as e:
+            return self._gate_error(e, "inspect threads")
         except Exception as e:
             return RpcResponse.error(f"Failed to fetch threads: {e}")
         thread = next((t for t in threads if t.id == thread_id), None)
@@ -657,7 +639,7 @@ class RpcHandlers:
             "Stack:",
         ]
         try:
-            frames = await self.controller.client.stack_trace(thread_id)
+            frames, scopes, variables = await self._inspect.thread_stack(thread_id)
             if frames:
                 for i, frame in enumerate(frames):
                     src = (
@@ -666,15 +648,10 @@ class RpcHandlers:
                         else "<unknown>"
                     )
                     lines.append(f"  #{i} {frame.name} at {src}:{frame.line}")
-                top = frames[0]
-                scopes = await self.controller.client.scopes(top.id)
                 lines.append("")
                 lines.append("Variables:")
                 for scope in scopes:
-                    variables = await self.controller.client.variables(
-                        scope.variables_reference
-                    )
-                    for v in variables:
+                    for v in variables.get(scope.variables_reference, []):
                         type_str = f" ({v.type})" if v.type else ""
                         lines.append(f"  {v.name}{type_str} = {v.value}")
             else:
@@ -684,13 +661,10 @@ class RpcHandlers:
         return RpcResponse.ok("\n".join(lines))
 
     async def action_list_processes(self, params: list[Any]) -> RpcResponse:
-        if self.controller.state.is_running:
-            return RpcResponse.error("Cannot list processes while program is running")
-        if self.controller.state.is_terminated:
-            return RpcResponse.error("Program has terminated")
         try:
-            raw = await self.controller.evaluate(PROCESS_COLLECT_EXPR)
-            processes = parse_process_json(raw)
+            processes = await self._inspect.collect_processes()
+        except SessionGateError as e:
+            return self._gate_error(e, "list processes")
         except Exception as e:
             return RpcResponse.error(f"Failed to collect processes: {e}")
         if not processes:
@@ -705,16 +679,11 @@ class RpcHandlers:
     async def action_inspect_process(self, params: list[Any]) -> RpcResponse:
         if not params:
             return RpcResponse.error("params[0] must be a process name or PID")
-        if self.controller.state.is_running:
-            return RpcResponse.error(
-                "Cannot inspect processes while program is running"
-            )
-        if self.controller.state.is_terminated:
-            return RpcResponse.error("Program has terminated")
         target = str(params[0])
         try:
-            raw = await self.controller.evaluate(PROCESS_COLLECT_EXPR)
-            processes = parse_process_json(raw)
+            processes = await self._inspect.collect_processes()
+        except SessionGateError as e:
+            return self._gate_error(e, "inspect processes")
         except Exception as e:
             return RpcResponse.error(f"Failed to collect processes: {e}")
         proc = None

--- a/src/tdb/session/inspect_service.py
+++ b/src/tdb/session/inspect_service.py
@@ -1,0 +1,265 @@
+"""Shared inspection workflows: fetch-and-parse logic used by both consumers.
+
+The TUI (`tdb.app_handlers.inspection.InspectionWorkflows`) and the
+JSON-RPC server (`tdb.server.handlers.RpcHandlers`) both implement the
+same "what is the program doing right now?" queries:
+
+  - enumerate asyncio tasks (evaluate ``TASK_COLLECT_EXPR`` in the
+    debuggee, parse the JSON),
+  - fetch one task's locals (evaluate ``TASK_LOCALS_EXPR`` against a
+    real frame id, expand the resulting variables reference),
+  - list threads, and fetch a thread's stack + scopes + variables,
+  - enumerate child processes (evaluate ``PROCESS_COLLECT_EXPR`` on the
+    parent, with a /proc fallback),
+  - fetch a child process's stack + scopes + variables via its DAPClient.
+
+Before this module existed, each consumer carried its own copy of those
+sequences and they drifted: the RPC server evaluated the process-collect
+expression on the *active* client (wrong when a child process is
+active) and had no /proc fallback, while task locals were resolved
+against the parent client instead of the active one. Centralizing the
+mechanics here gives both consumers the corrected behavior and leaves
+them with presentation only (textual modals / RpcResponse text).
+
+Like `tdb.inspection`, this module is UI-free: no textual, no FastAPI.
+It speaks in `tdb.dap.types` and `tdb.inspection` dataclasses, raising
+`SessionGateError` instead of rendering "program is running" messages so
+each consumer keeps its own wording (toast vs RPC error string).
+
+The service holds a *provider* callable rather than a controller because
+the RPC layer swaps controllers on restart (see
+`tdb.server.handlers.ControllerRef`); reading through the provider on
+every call keeps the service pointed at the live controller.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
+
+from tdb.dap.types import Scope, StackFrame, Thread, Variable
+from tdb.inspection import (
+    PROCESS_COLLECT_EXPR,
+    ProcessInfo,
+    TASK_COLLECT_EXPR,
+    TASK_LOCALS_EXPR,
+    AsyncTaskInfo,
+    parse_process_json,
+    parse_task_json,
+)
+
+if TYPE_CHECKING:
+    from tdb.session.controller import DebugController
+
+log = logging.getLogger(__name__)
+
+
+class SessionGateError(Exception):
+    """The session is in a phase where inspection is impossible.
+
+    ``reason`` is ``"running"`` (debuggee executing — no frames to
+    inspect; pause first) or ``"terminated"`` (session over). Consumers
+    translate the reason into their own user-facing wording.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+# Stack/scope/variable bundle returned by `thread_stack` and
+# `process_stack`. `variables` is keyed by each scope's
+# variables_reference — the shape the TUI modals consume directly; the
+# RPC handlers flatten it for text output.
+StackDetail = tuple[
+    list[StackFrame],
+    list[Scope],
+    dict[int, list[Variable]],
+]
+
+
+class InspectService:
+    """Controller-backed implementation of the shared inspection queries."""
+
+    def __init__(self, controller_provider: Callable[[], "DebugController"]) -> None:
+        self._provider = controller_provider
+
+    @property
+    def _ctrl(self) -> "DebugController":
+        return self._provider()
+
+    def _gate(self) -> None:
+        """Raise SessionGateError unless the debuggee is inspectable."""
+        state = self._ctrl.state
+        if state.is_terminated:
+            raise SessionGateError("terminated")
+        if state.is_running:
+            raise SessionGateError("running")
+
+    # --- asyncio tasks ---------------------------------------------------
+
+    async def collect_tasks(self) -> list[AsyncTaskInfo]:
+        """Enumerate asyncio tasks by evaluating in the debuggee.
+
+        Raises SessionGateError when not inspectable; raises whatever
+        `parse_task_json` raises when the evaluate result isn't the
+        expected JSON (typically because the evaluate itself failed and
+        `controller.evaluate` returned the error string).
+        """
+        self._gate()
+        raw = await self._ctrl.evaluate(TASK_COLLECT_EXPR)
+        tasks = parse_task_json(raw)
+        if not tasks:
+            # Surface the raw payload at debug level — the most common
+            # cause is "program doesn't use asyncio", but a truncated or
+            # error payload is worth being able to see.
+            log.debug(
+                "Task collection returned no tasks. Raw: %s",
+                raw[:300] if raw else "(empty)",
+            )
+        return tasks
+
+    async def task_locals(self, task_name: str) -> list[Variable]:
+        """Fetch one task's local variables, expanded one level.
+
+        Evaluates against the *active* client (parent or child —
+        whichever process is being inspected) with a real frame id, so
+        it works after synthetic-frame task navigation. Returns [] when
+        the frame isn't available rather than raising: both consumers
+        render that as a "(no variables)" state.
+        """
+        self._gate()
+        ctrl = self._ctrl
+        try:
+            expr = TASK_LOCALS_EXPR.format(task_name=task_name)
+            # Route around synthetic (negative) frame ids installed by
+            # task navigation — debugpy rejects them.
+            frame_id = await ctrl.resolve_evaluate_frame_id(ctrl.active_client)
+            _result, var_ref = await ctrl.active_client.evaluate(
+                expr,
+                frame_id=frame_id,
+                context="repl",
+            )
+            if var_ref > 0:
+                return await ctrl.active_client.variables(var_ref)
+        except Exception:
+            log.debug("Failed to load variables for task %s", task_name)
+        return []
+
+    # --- threads ----------------------------------------------------------
+
+    async def list_threads(self) -> list[Thread]:
+        """List the debuggee's threads. Raises on gate or DAP failure."""
+        self._gate()
+        return await self._ctrl.client.threads()
+
+    async def thread_stack(self, thread_id: int) -> StackDetail:
+        """Fetch a thread's stack, plus scopes + variables of its top frame.
+
+        Raises on gate failure or if the stack trace itself can't be
+        fetched. Scope/variable expansion is best-effort: a failure
+        there returns whatever was gathered so far.
+        """
+        self._gate()
+        client = self._ctrl.client
+        frames = await client.stack_trace(thread_id)
+        scopes: list[Scope] = []
+        variables: dict[int, list[Variable]] = {}
+        if frames:
+            try:
+                scopes = await client.scopes(frames[0].id)
+                for scope in scopes:
+                    variables[scope.variables_reference] = await client.variables(
+                        scope.variables_reference
+                    )
+            except Exception:
+                log.debug("Failed to fetch variables for thread %d", thread_id)
+        return frames, scopes, variables
+
+    # --- child processes ---------------------------------------------------
+
+    async def collect_processes(self) -> list[ProcessInfo]:
+        """Enumerate multiprocessing children.
+
+        Primary source: evaluate ``PROCESS_COLLECT_EXPR`` on the
+        *parent* process (children don't know their siblings). Fallback:
+        build entries from the controller's tracked child PIDs via
+        /proc (Linux), which still works when the parent isn't paused in
+        a frame we can evaluate against.
+        """
+        self._gate()
+        try:
+            raw = await self._ctrl.evaluate_on_parent(PROCESS_COLLECT_EXPR)
+            processes = parse_process_json(raw)
+            if processes:
+                return processes
+        except Exception:
+            log.debug("Process collection via evaluate failed", exc_info=True)
+        return self._processes_from_pids()
+
+    def _processes_from_pids(self) -> list[ProcessInfo]:
+        """Build ProcessInfo entries from tracked child PIDs via /proc.
+
+        Linux-only fallback used when DAP `evaluate` against the parent
+        is unavailable (e.g., the parent isn't the active process).
+        """
+        result: list[ProcessInfo] = []
+        for pid in self._ctrl.get_child_pids():
+            try:
+                cmdline_path = Path(f"/proc/{pid}/cmdline")
+                if not cmdline_path.exists():
+                    continue
+                cmdline = (
+                    cmdline_path.read_bytes().replace(b"\x00", b" ").decode().strip()
+                )
+                status_path = Path(f"/proc/{pid}/status")
+                name = f"Process-{pid}"
+                if status_path.exists():
+                    for line in status_path.read_text().splitlines():
+                        if line.startswith("Name:"):
+                            name = line.split(":", 1)[1].strip()
+                            break
+                result.append(
+                    ProcessInfo(
+                        name=name,
+                        pid=pid,
+                        alive=True,
+                        exitcode=None,
+                        daemon=False,
+                        target=cmdline[:200] if cmdline else "unknown",
+                        args="()",
+                        kwargs="{}",
+                        start_method="",
+                    )
+                )
+            except Exception:
+                pass
+        return result
+
+    async def process_stack(self, pid: int) -> StackDetail | None:
+        """Fetch a child process's stack + scopes + variables.
+
+        Returns None when the pid has no tracked DAPClient (PIDs from
+        /proc may not match the controller's keys). Per-step failures
+        inside the fetch are best-effort, mirroring `thread_stack`.
+        """
+        child = self._ctrl.get_child_client(pid)
+        if child is None:
+            return None
+        frames: list[StackFrame] = []
+        scopes: list[Scope] = []
+        variables: dict[int, list[Variable]] = {}
+        try:
+            threads = await child.threads()
+            if threads:
+                frames = await child.stack_trace(threads[0].id)
+                if frames:
+                    scopes = await child.scopes(frames[0].id)
+                    for scope in scopes:
+                        variables[scope.variables_reference] = await child.variables(
+                            scope.variables_reference
+                        )
+        except Exception:
+            log.debug("Failed to fetch detail for child process %d", pid)
+        return frames, scopes, variables

--- a/tests/unit/test_inspect_service.py
+++ b/tests/unit/test_inspect_service.py
@@ -1,0 +1,273 @@
+"""Unit tests for tdb.session.inspect_service.InspectService.
+
+The service is the shared fetch-and-parse layer behind both the TUI's
+InspectionWorkflows and the RPC server's task/thread/process actions.
+Tests use a real DebugController (cheap to construct) with monkeypatched
+evaluate / client methods, mirroring the style of test_rpc_handlers.py.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tdb.dap.types import Scope, Source, StackFrame, Thread, Variable
+from tdb.server.event_handler import ServerEventHandler
+from tdb.session.controller import DebugController
+from tdb.session.inspect_service import InspectService, SessionGateError
+from tdb.session.state import SessionPhase
+
+
+def _service(phase: SessionPhase = SessionPhase.STOPPED):
+    controller = DebugController(ServerEventHandler())
+    controller.state.transition_to(phase)
+    return InspectService(lambda: controller), controller
+
+
+def _task_payload(name: str = "Task-1", awaiting: str | None = None) -> str:
+    return json.dumps(
+        [
+            {
+                "name": name,
+                "state": "pending",
+                "coro": "main()",
+                "stack": ["main at /app/main.py:10"],
+                "awaiting": awaiting,
+            }
+        ]
+    )
+
+
+# --- Gates ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "phase,reason",
+    [
+        (SessionPhase.RUNNING, "running"),
+        (SessionPhase.TERMINATED, "terminated"),
+    ],
+)
+async def test_collect_tasks_gates(phase, reason):
+    svc, _ = _service(phase)
+    with pytest.raises(SessionGateError) as ei:
+        await svc.collect_tasks()
+    assert ei.value.reason == reason
+
+
+async def test_list_threads_gates_when_running():
+    svc, _ = _service(SessionPhase.RUNNING)
+    with pytest.raises(SessionGateError):
+        await svc.list_threads()
+
+
+async def test_collect_processes_gates_when_terminated():
+    svc, _ = _service(SessionPhase.TERMINATED)
+    with pytest.raises(SessionGateError):
+        await svc.collect_processes()
+
+
+# --- Tasks ---------------------------------------------------------------
+
+
+async def test_collect_tasks_parses_payload(monkeypatch):
+    svc, ctrl = _service()
+
+    async def fake_evaluate(expr: str) -> str:
+        return _task_payload(awaiting="Lock.acquire")
+
+    monkeypatch.setattr(ctrl, "evaluate", fake_evaluate)
+    tasks = await svc.collect_tasks()
+    assert len(tasks) == 1
+    assert tasks[0].name == "Task-1"
+    assert tasks[0].awaiting == "Lock.acquire"
+
+
+async def test_collect_tasks_empty_on_unparseable_payload(monkeypatch):
+    """When the in-debuggee evaluate failed, controller.evaluate returns
+    the error string. `parse_task_json` swallows the parse failure and
+    yields [] (logging the payload) — preserved here so both consumers
+    keep their established 'no tasks found' rendering for that case."""
+    svc, ctrl = _service()
+
+    async def fake_evaluate(expr: str) -> str:
+        return "NameError: name 'asyncio' is not defined"
+
+    monkeypatch.setattr(ctrl, "evaluate", fake_evaluate)
+    assert await svc.collect_tasks() == []
+
+
+async def test_task_locals_returns_empty_on_failure(monkeypatch):
+    """A dead frame / failed evaluate renders as 'no variables', not an
+    exception — both consumers display an empty-variables state."""
+    svc, ctrl = _service()
+
+    async def boom(*a, **k):
+        raise RuntimeError("no frame")
+
+    monkeypatch.setattr(ctrl, "resolve_evaluate_frame_id", boom)
+    assert await svc.task_locals("Task-1") == []
+
+
+async def test_task_locals_uses_active_client(monkeypatch):
+    """Locals must be evaluated against the *active* client (which may be
+    a child process), not unconditionally against the parent."""
+    svc, ctrl = _service()
+    calls = SimpleNamespace(evaluated_on=None)
+
+    class FakeClient:
+        async def evaluate(self, expr, frame_id=None, context="repl"):
+            calls.evaluated_on = self
+            return "ok", 7
+
+        async def variables(self, ref):
+            assert ref == 7
+            return [Variable(name="x", value="1", type="int")]
+
+    fake = FakeClient()
+    monkeypatch.setattr(
+        type(ctrl), "active_client", property(lambda self: fake)
+    )
+
+    async def fake_resolve(client):
+        assert client is fake
+        return 99
+
+    monkeypatch.setattr(ctrl, "resolve_evaluate_frame_id", fake_resolve)
+    variables = await svc.task_locals("Task-1")
+    assert calls.evaluated_on is fake
+    assert [v.name for v in variables] == ["x"]
+
+
+# --- Threads ---------------------------------------------------------------
+
+
+async def test_thread_stack_shape(monkeypatch):
+    svc, ctrl = _service()
+    frame = StackFrame(
+        id=1, name="main", source=Source(path="/app/main.py"), line=3
+    )
+    scope = Scope(name="Locals", variables_reference=11)
+
+    class FakeClient:
+        async def stack_trace(self, tid):
+            assert tid == 5
+            return [frame]
+
+        async def scopes(self, frame_id):
+            assert frame_id == 1
+            return [scope]
+
+        async def variables(self, ref):
+            return [Variable(name="n", value="42", type="int")]
+
+    monkeypatch.setattr(ctrl, "client", FakeClient())
+    frames, scopes, variables = await svc.thread_stack(5)
+    assert frames == [frame]
+    assert scopes == [scope]
+    assert [v.name for v in variables[11]] == ["n"]
+
+
+async def test_thread_stack_variables_best_effort(monkeypatch):
+    """Scope/variable failures degrade to partial results — the stack is
+    still useful without locals."""
+    svc, ctrl = _service()
+    frame = StackFrame(id=1, name="main", source=None, line=3)
+
+    class FakeClient:
+        async def stack_trace(self, tid):
+            return [frame]
+
+        async def scopes(self, frame_id):
+            raise RuntimeError("scopes unavailable")
+
+    monkeypatch.setattr(ctrl, "client", FakeClient())
+    frames, scopes, variables = await svc.thread_stack(5)
+    assert frames == [frame]
+    assert scopes == []
+    assert variables == {}
+
+
+async def test_list_threads_passthrough(monkeypatch):
+    svc, ctrl = _service()
+    expected = [Thread(id=1, name="MainThread")]
+
+    class FakeClient:
+        async def threads(self):
+            return expected
+
+    monkeypatch.setattr(ctrl, "client", FakeClient())
+    assert await svc.list_threads() == expected
+
+
+# --- Processes ---------------------------------------------------------------
+
+
+async def test_collect_processes_evaluates_on_parent(monkeypatch):
+    """The collect expression must run on the parent — children don't
+    know their siblings. This was the behavior the TUI had and the RPC
+    server lacked before the shared service existed."""
+    svc, ctrl = _service()
+    payload = json.dumps(
+        [
+            {
+                "name": "Worker-1",
+                "pid": 4242,
+                "alive": True,
+                "exitcode": None,
+                "daemon": False,
+                "target": "work()",
+                "args": "()",
+                "kwargs": "{}",
+                "start_method": "fork",
+            }
+        ]
+    )
+    called = SimpleNamespace(on_parent=False)
+
+    async def fake_on_parent(expr: str) -> str:
+        called.on_parent = True
+        return payload
+
+    monkeypatch.setattr(ctrl, "evaluate_on_parent", fake_on_parent)
+    processes = await svc.collect_processes()
+    assert called.on_parent
+    assert processes[0].pid == 4242
+
+
+async def test_collect_processes_falls_back_to_proc(monkeypatch):
+    """When the parent evaluate fails, fall back to /proc entries built
+    from tracked child PIDs. With no tracked children that's []."""
+    svc, ctrl = _service()
+
+    async def fake_on_parent(expr: str) -> str:
+        raise RuntimeError("parent not stopped")
+
+    monkeypatch.setattr(ctrl, "evaluate_on_parent", fake_on_parent)
+    monkeypatch.setattr(ctrl, "get_child_pids", lambda: [])
+    assert await svc.collect_processes() == []
+
+
+async def test_process_stack_none_without_client(monkeypatch):
+    svc, ctrl = _service()
+    monkeypatch.setattr(ctrl, "get_child_client", lambda pid: None)
+    assert await svc.process_stack(1234) is None
+
+
+async def test_service_follows_controller_swap():
+    """The provider indirection must track ControllerRef-style swaps."""
+    first = DebugController(ServerEventHandler())
+    first.state.transition_to(SessionPhase.TERMINATED)
+    holder = SimpleNamespace(ctrl=first)
+    svc = InspectService(lambda: holder.ctrl)
+    with pytest.raises(SessionGateError):
+        await svc.collect_tasks()
+
+    second = DebugController(ServerEventHandler())
+    second.state.transition_to(SessionPhase.RUNNING)
+    holder.ctrl = second
+    with pytest.raises(SessionGateError) as ei:
+        await svc.collect_tasks()
+    assert ei.value.reason == "running"

--- a/tests/unit/test_rpc_handlers.py
+++ b/tests/unit/test_rpc_handlers.py
@@ -497,3 +497,69 @@ async def test_wait_graph_in_dispatch_table(handlers):
     assert "wait_graph" in handlers.dispatch_table()
     assert "wait_graph" in RpcHandlers.ACTIONS
     assert "wait_graph" in RpcHandlers.ACTION_HELP
+
+# --- Mid-action gate races (phase changes between service calls) --------
+#
+# Inspector actions make more than one InspectService call (e.g.
+# inspect_task: collect_tasks then task_locals; inspect_thread:
+# list_threads then thread_stack). The service re-gates on every entry,
+# so a `terminated` / `continued` DAP event landing between the calls
+# raises SessionGateError mid-action. The handler must map that to the
+# same wording as the up-front gate — not let it escape to the
+# dispatcher's generic exception handler, and not mislabel it as a
+# fetch failure.
+
+
+async def test_inspect_task_gate_race_maps_to_gate_error(handlers, monkeypatch):
+    from tdb.session import inspect_service as _isvc
+
+    ctrl = handlers.controller
+    payload = _json.dumps(
+        [{"name": "Task-1", "state": "pending", "coro": "main()", "stack": []}]
+    )
+
+    async def fake_evaluate(expr: str) -> str:
+        return payload
+
+    monkeypatch.setattr(ctrl, "evaluate", fake_evaluate)
+
+    # Flip the phase after collect_tasks succeeds but before task_locals
+    # gates, by hooking resolve_evaluate_frame_id (first await inside
+    # task_locals after its gate would be too late — so flip inside the
+    # gate's read path instead: transition right before calling).
+    original_gate = _isvc.InspectService._gate
+
+    def racing_gate(self):
+        original_gate(self)
+        # After the first successful gate (collect_tasks), terminate the
+        # session so the *next* gate (task_locals) trips.
+        ctrl.state.transition_to(SessionPhase.TERMINATED)
+
+    monkeypatch.setattr(_isvc.InspectService, "_gate", racing_gate)
+
+    rsp = await handlers.action_inspect_task(["Task-1"])
+    assert rsp.success is False
+    assert rsp.value == "Program has terminated"
+
+
+async def test_inspect_thread_gate_race_maps_to_gate_error(handlers, monkeypatch):
+    from tdb.session import inspect_service as _isvc
+
+    ctrl = handlers.controller
+    ctrl.client._threads = [Thread(id=1, name="MainThread")]
+
+    original_gate = _isvc.InspectService._gate
+
+    def racing_gate(self):
+        original_gate(self)
+        # list_threads gates first and passes; thread_stack's gate then
+        # sees RUNNING.
+        ctrl.state.transition_to(SessionPhase.RUNNING)
+
+    monkeypatch.setattr(_isvc.InspectService, "_gate", racing_gate)
+
+    rsp = await handlers.action_inspect_thread([1])
+    assert rsp.success is False
+    assert rsp.value == "Cannot inspect threads while program is running"
+    # Specifically: the race must NOT be mislabeled as a stack failure.
+    assert "failed to fetch stack trace" not in rsp.value


### PR DESCRIPTION
> PR by Anthropic Fable

# Extract shared `InspectService` from TUI and RPC inspector workflows

## Problem

The TUI (`app_handlers/inspection.py`) and the JSON-RPC server (`server/handlers.py`) each carried their own copy of the task / thread / process inspection mechanics: evaluate `TASK_COLLECT_EXPR` or `PROCESS_COLLECT_EXPR` in the debuggee, parse the JSON, walk stack → scopes → variables over DAP. The data layer (`tdb/inspection.py`) was already shared, but the orchestration above it existed twice, and the copies had drifted:

- The RPC server evaluated `PROCESS_COLLECT_EXPR` on the **active** client.  When a child process is the active one (any stop in a multiprocessing child), that's the wrong process — children don't know their siblings —  so `list_processes` / `inspect_process` could come back empty exactly when you'd want them. The TUI evaluated on the parent and additionally had a `/proc`-based fallback; the server had neither.
- The RPC server resolved task locals against the **parent** client (`controller.client`) while the TUI used controller.active_client`, so `inspect_task` variables could fail after a child-process stop.

## Change

New module **`src/tdb/session/inspect_service.py`** holds the shared mechanics, UI-free (no textual, no FastAPI — same import discipline as tdb/inspection.py`):

| Method | Replaces |
|---|---|
| `collect_tasks()` | 3 copies in RPC handlers + 2 in the TUI |
| `task_locals(name)` | RPC `action_inspect_task` inline block + TUI `load_task_variables` |
| `list_threads()` | both consumers' `client.threads()` + gating |
| `thread_stack(tid)` | RPC `action_inspect_thread` traversal + TUI `load_thread_detail` |
| `collect_processes()` | RPC eval + TUI eval-on-parent + `/proc` fallback |
| `process_stack(pid)` | TUI `load_process_detail` traversal |

Phase gating raises `SessionGateError("running" | "terminated")` so each
consumer keeps its own wording (toast vs. RPC error string — all
established RPC response strings are preserved). The service reads its
controller through a provider callable, so it follows `ControllerRef`
swaps on restart in dual mode.

Both consumers are rewritten on top of it:

- `RpcHandlers`: the seven inspector actions delegate to the service.
- `InspectionWorkflows`: now presentation-only (gates rendered as toasts, modal lifecycle, menu-bar labels).

## Behavioral changes (intentional)

1. `list_processes` / `inspect_process` over RPC now evaluate on the parent and fall back to `/proc` — adopting the TUI's (correct) behavior.
2. `inspect_task` locals over RPC now evaluate against the active client — adopting the TUI's (correct) behavior.
3. `inspect_thread` over RPC: when the stack fetch succeeds but scope/variable expansion fails, the response now degrades to frames with partial/no variables instead of replacing everything with "(failed to fetch stack trace)". Hard stack-trace failures still produce that line.

## Testing

- `tests/unit/test_inspect_service.py` (15 new tests): gates, the parent-eval requirement for process collection, `/proc` fallback, best-effort degradation in `thread_stack`, empty-on-failure contract of `task_locals`, active-client routing, and controller-swap tracking.
- Full suite: 448 unit + 18 integration tests pass.
- Manual smoke against `examples/asyncio_deadlock.py` in `--headless` mode: `list_tasks`, `wait_graph`, `inspect_task`, `list_threads`, `list_processes` produce output identical to `main` at the same stop point (modulo object addresses).

Net: ~120 lines of duplicated DAP traversal removed; one place to fix when the inspection mechanics change, and one place for a future third consumer (e.g. an MCP server) to build on.