### PR TITLE
add stdio-based MCP service

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,11 +673,12 @@ curl -s -X POST http://127.0.0.1:8150/rpc \
 | `set_breakpoint` | `["file:line"]` or `["file:line", "condition", "hit_condition"]` | Set a breakpoint |
 | `remove_breakpoint` | `["file:line"]` | Remove a breakpoint |
 | `list_breakpoints` | `[]` | Show all breakpoints |
-| `continue` | `[]` | Resume execution |
-| `next` | `[]` | Step over |
-| `step_in` | `[]` | Step into |
-| `step_out` | `[]` | Step out |
-| `pause` | `[]` | Pause execution |
+| `continue` | `[]` or `[timeout_s]` | Resume execution; on timeout returns `"still running — call pause or wait again"` (success) |
+| `next` | `[]` or `[timeout_s]` | Step over |
+| `step_in` | `[]` or `[timeout_s]` | Step into |
+| `step_out` | `[]` or `[timeout_s]` | Step out |
+| `pause` | `[]` | Pause execution; bypasses the dispatch lock so it can interrupt an in-flight blocking action |
+| `wait_for_stop` | `[]` or `[timeout_s]` | Wait for the next stop without issuing a step (use after `continue` returns `"still running"` to keep waiting) |
 | `inspect` | `["expr1", "expr2", ...]` | Evaluate multiple expressions |
 | `evaluate` | `["expression"]` | Evaluate a single expression |
 | `stack_up` | `[]` | Move up the call stack |
@@ -705,6 +706,84 @@ curl -N http://127.0.0.1:8150/events
 
 Events: `initialized`, `stopped`, `continued`, `terminated`, `exited`, `output`.
 Each is JSON with `event`, `data`, and `timestamp` fields.
+
+## MCP Integration
+
+tdb ships a Model Context Protocol (MCP) server (`tdb-mcp`) that exposes
+the debugger as a curated set of tools an AI agent can call. The MCP
+server is a third in-process consumer of the same dispatch handlers the
+TUI and the HTTP server use — so an agent gets the same lock semantics,
+including the pause-during-continue bypass, and the same DAP-backed
+inspection surface.
+
+### Running the MCP server
+
+Configure your MCP client (Claude Desktop, an IDE extension, etc.) to
+launch `tdb-mcp` over stdio. Example `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "tdb": {
+      "command": "tdb-mcp"
+    }
+  }
+}
+```
+
+Three equivalent invocation forms: `tdb-mcp` (the dedicated entry
+point), `tdb --mcp` (the main CLI with the `--mcp` switch), and
+`python -m tdb.mcp` (module form). Pick whichever matches how your MCP
+client expects to launch servers.
+
+### Tool surface (16 tools, curated)
+
+| Cluster | Tools |
+|---------|-------|
+| Lifecycle | `debug_launch`, `debug_attach`, `quit` |
+| Control | `control(action, timeout_s=30)` — `action ∈ {continue, next, step_in, step_out, pause, wait_for_stop}` |
+| Inspection | `inspect(expressions)`, `read_source(file_path)`, `stack_trace()`, `status()`, `get_output()` |
+| Breakpoints | `set_breakpoint(spec, condition?, hit_condition?)`, `remove_breakpoint(spec)`, `list_breakpoints()` |
+| Differentiators | `threads(thread_id?)`, `tasks(task_name?)`, `processes(name_or_pid?)`, `wait_graph()` |
+
+`control` is intentionally one tool that takes an action enum — the six
+underlying RPC actions share a return shape, and agents perform
+measurably better with a small surface than with one tool per action.
+`threads` / `tasks` / `processes` overload list-vs-inspect via a
+single optional argument for the same reason.
+
+### Agent flow for a long-running step
+
+```
+agent → control(action="continue", timeout_s=30)
+mcp   → "still running — call pause or wait again"
+agent → control(action="pause")        # OR: control(action="wait_for_stop", timeout_s=30)
+mcp   → "<file>:<line>"
+agent → inspect(["x", "len(buf)"])
+mcp   → "x = 7\nlen(buf) = 1024"
+```
+
+`pause` bypasses the dispatch lock so it can interrupt a `continue`
+that's still mid-flight (HTTP and MCP share the same `NO_LOCK_ACTIONS`
+policy — see `tdb/server/app.py`).
+
+### Security caveat
+
+`inspect` calls debugpy's `evaluate`, which is **arbitrary Python
+execution in the debuggee process**. This is inherent to a debugger and
+not a tdb-specific concern, but MCP clients (and the humans running
+them) should apply appropriate permission models: don't auto-approve
+`inspect` against untrusted expressions, and don't expose `tdb-mcp` on
+a network — stdio transport only by design.
+
+### Deferred / out of scope (v1)
+
+- SSE-style event push — `control` and `wait_for_stop` make polling
+  efficient enough; events would also need uneven MCP-client support.
+- HTTP / streamable-HTTP transports — would require auth (which the
+  HTTP RPC server also currently lacks); stdio inherits the trust of
+  the process that spawned it.
+- Multi-session — one debug session per MCP process.
 
 ## CLI Reference
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@
       "pygments>=2.17.0",
       "fastapi>=0.115.0",
       "uvicorn>=0.30.0",
-  ]
+      "mcp>=1.28.0",
+]
 
   # extras needed to run the examples and tests
   [project.optional-dependencies]
@@ -43,6 +44,7 @@
 
   [project.scripts]
   tdb = "tdb.cli:main"
+  tdb-mcp = "tdb.mcp.server:main"
 
   [build-system]
   requires = ["setuptools>=68.0"]

--- a/src/tdb/cli.py
+++ b/src/tdb/cli.py
@@ -137,6 +137,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run as a headless JSON-RPC debug server (no TUI)",
     )
     parser.add_argument(
+        "--mcp",
+        action="store_true",
+        help="Run as a Model Context Protocol (MCP) server over stdio. "
+        "Equivalent to `python -m tdb.mcp`. The session is owned by the "
+        "MCP client (via debug_launch / debug_attach tools); no program "
+        "argument is needed on the CLI.",
+    )
+    parser.add_argument(
         "-k",
         "--breakpoint",
         action="append",
@@ -412,7 +420,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     args = parser.parse_args(argv)
     _apply_flag_implications(args)
 
-    if args.doc or args.doc_text or args.post_mortem:
+    if args.doc or args.doc_text or args.post_mortem or args.mcp:
         return args
 
     _validate_terminal_choice(args, parser)
@@ -456,10 +464,19 @@ def main(argv: list[str] | None = None) -> None:
         _run_doc_text()
     elif args.post_mortem:
         _run_post_mortem(args)
+    elif args.mcp:
+        _run_mcp()
     elif args.headless:
         _run_headless(args)
     else:
         _run_tui(args)
+
+
+def _run_mcp() -> None:
+    """Launch the MCP server over stdio. Mirrors `python -m tdb.mcp`."""
+    from tdb.mcp.server import main as mcp_main
+
+    mcp_main()
 
 
 def _run_doc() -> None:

--- a/src/tdb/mcp/__init__.py
+++ b/src/tdb/mcp/__init__.py
@@ -5,6 +5,6 @@ FastAPI/HTTP server. Speaks MCP over stdio so an MCP client (Claude
 Desktop, IDE extensions, etc.) can drive a tdb debug session as a set
 of tools.
 
-Entry point: `tdb-mcp` (registered in pyproject.toml) or
+Entry point: `tdb-mcp` (registered in pyproject.toml), `tdb --mcp`, or
 `python -m tdb.mcp`.
 """

--- a/src/tdb/mcp/__init__.py
+++ b/src/tdb/mcp/__init__.py
@@ -1,0 +1,10 @@
+"""Model Context Protocol (MCP) server for tdb.
+
+Third in-process consumer of `RpcHandlers` — alongside the TUI and the
+FastAPI/HTTP server. Speaks MCP over stdio so an MCP client (Claude
+Desktop, IDE extensions, etc.) can drive a tdb debug session as a set
+of tools.
+
+Entry point: `tdb-mcp` (registered in pyproject.toml) or
+`python -m tdb.mcp`.
+"""

--- a/src/tdb/mcp/__main__.py
+++ b/src/tdb/mcp/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point: `python -m tdb.mcp`. Delegates to server.main()."""
+
+from .server import main
+
+if __name__ == "__main__":
+    main()

--- a/src/tdb/mcp/server.py
+++ b/src/tdb/mcp/server.py
@@ -65,7 +65,15 @@ def _parse_path_mappings(
     normalize to a list of tuples for the DAP client."""
     if not mappings:
         return None
-    return [(str(pair[0]), str(pair[1])) for pair in mappings]
+    out: list[tuple[str, str]] = []
+    for pair in mappings:
+        if len(pair) != 2:
+            raise ValueError(
+                "path_mappings entries must be [local_root, remote_root], got "
+                f"{pair!r}"
+            )
+        out.append((str(pair[0]), str(pair[1])))
+    return out
 
 
 def build_mcp(session: McpSession | None = None) -> FastMCP:

--- a/src/tdb/mcp/server.py
+++ b/src/tdb/mcp/server.py
@@ -1,0 +1,299 @@
+"""FastMCP server exposing tdb as a Model Context Protocol tool surface.
+
+15 curated tools (not 26 auto-generated) so the agent's tool list stays
+small and focused. Tool wrappers translate kwargs → JSON-RPC `params`
+list and call through `McpSession._call`, which preserves the HTTP
+dispatcher's lock policy — `pause` bypasses `session_lock` so an agent
+can interrupt a runaway `control(action="continue")` mid-flight.
+
+Stdio transport only. Single debug session per process. Events (DAP
+SSE stream) are deferred — the `wait_for_stop` action and the
+short-timeout `control` polling pattern make events unnecessary for v1.
+
+SECURITY: the `inspect` tool calls debugpy's `evaluate`, which is
+arbitrary Python execution in the debuggee process. MCP clients should
+apply their permission models accordingly (Claude Desktop, IDE
+extensions, etc. typically prompt before invoking tools).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from mcp.server.fastmcp import FastMCP
+
+from tdb.server.rpc_types import RpcResponse
+from .session import McpSession
+
+log = logging.getLogger(__name__)
+
+
+# Single shared session for the entry-point's FastMCP instance. Tests
+# construct their own session + FastMCP via `build_mcp(session=...)` so
+# they don't collide with this module-level state.
+_session = McpSession()
+
+
+def _format(rsp: RpcResponse) -> str:
+    """Render an RpcResponse as the string an MCP tool returns. Errors
+    are prefixed `Error:` so agents distinguish failure from success
+    payloads (e.g. the "still running" sentinel returned by `control`)."""
+    if rsp.success:
+        return rsp.value or "ok"
+    return f"Error: {rsp.value}"
+
+
+def _parse_breakpoints(specs: list[str] | None) -> list[tuple[str, int]] | None:
+    """Convert ['file.py:42', ...] → [(path, line), ...]. Returns None
+    when the input is None/empty so McpSession.launch can short-circuit."""
+    if not specs:
+        return None
+    out: list[tuple[str, int]] = []
+    for spec in specs:
+        if ":" not in spec:
+            raise ValueError(f"breakpoint spec must be 'file:line', got {spec!r}")
+        file_part, line_part = spec.rsplit(":", 1)
+        out.append((file_part, int(line_part)))
+    return out
+
+
+def _parse_path_mappings(
+    mappings: list[list[str]] | list[tuple[str, str]] | None,
+) -> list[tuple[str, str]] | None:
+    """Accept [['local', 'remote'], ...] (JSON's array-of-arrays) and
+    normalize to a list of tuples for the DAP client."""
+    if not mappings:
+        return None
+    return [(str(pair[0]), str(pair[1])) for pair in mappings]
+
+
+def build_mcp(session: McpSession | None = None) -> FastMCP:
+    """Build a FastMCP instance wired to the given session (or the
+    module-level shared one). Factored out so tests can construct an
+    isolated server."""
+    sess = session or _session
+    mcp = FastMCP(
+        "tdb",
+        instructions=(
+            "tdb is a Python debugger driven via DAP. Use `debug_launch` "
+            "or `debug_attach` to start a session, `control` to step / "
+            "continue / pause, and the `inspect` / stack / variable "
+            "tools to examine state at a stopped frame. `control` and "
+            "`wait_for_stop` return the sentinel 'still running — call "
+            "pause or wait again' on timeout; respond with `control "
+            "action=pause` to interrupt or `control action=wait_for_stop` "
+            "to keep waiting. `inspect` executes arbitrary Python in the "
+            "debuggee — surface that to the user before evaluating "
+            "untrusted expressions."
+        ),
+    )
+
+    # --- Lifecycle ----------------------------------------------------
+
+    @mcp.tool(description="Start debugging a local Python program.")
+    async def debug_launch(
+        program: str,
+        args: list[str] | None = None,
+        cwd: str | None = None,
+        stop_on_entry: bool = False,
+        just_my_code: bool = True,
+        python: str | None = None,
+        breakpoints: list[str] | None = None,
+    ) -> str:
+        """Launch `program` under the debugger. `breakpoints` is a list
+        of 'file.py:42' specs set before the program starts running. If
+        `stop_on_entry` is true the debuggee pauses at the first line;
+        otherwise it runs until the first breakpoint or terminates.
+        Returns a status line indicating where the debuggee landed."""
+        return await sess.launch(
+            program=program,
+            args=args,
+            cwd=cwd,
+            stop_on_entry=stop_on_entry,
+            just_my_code=just_my_code,
+            python=python,
+            breakpoints=_parse_breakpoints(breakpoints),
+        )
+
+    @mcp.tool(description="Attach to a remote debugpy server (host:port).")
+    async def debug_attach(
+        host: str,
+        port: int,
+        breakpoints: list[str] | None = None,
+        path_mappings: list[list[str]] | None = None,
+    ) -> str:
+        """Attach to a debugpy server already listening on host:port.
+        `path_mappings` is a list of [local_root, remote_root] pairs
+        forwarded to debugpy for bidirectional path translation (use
+        when tdb and the remote program have copies of the same code
+        at different paths). The session pauses on attach so you can
+        set breakpoints / inspect state immediately."""
+        return await sess.attach(
+            host=host,
+            port=port,
+            breakpoints=_parse_breakpoints(breakpoints),
+            path_mappings=_parse_path_mappings(path_mappings),
+        )
+
+    @mcp.tool(description="Stop the current debug session.")
+    async def quit() -> str:
+        """Tear down the active session. Safe to call when no session
+        is active. After `quit`, a fresh `debug_launch` / `debug_attach`
+        can start a new session in the same MCP process."""
+        return await sess.quit()
+
+    # --- Control (single tool, consolidates 6 actions) ---------------
+
+    @mcp.tool(description="Step, continue, pause, or wait for the next stop.")
+    async def control(
+        action: Literal[
+            "continue",
+            "next",
+            "step_in",
+            "step_out",
+            "pause",
+            "wait_for_stop",
+        ],
+        timeout_s: float = 30.0,
+    ) -> str:
+        """Drive the debuggee. `continue` / `next` / `step_in` /
+        `step_out` issue a step and wait up to `timeout_s` for the
+        next stop. On timeout, returns the sentinel 'still running —
+        call pause or wait again'; respond by calling this tool again
+        with `action="pause"` to interrupt, or `action="wait_for_stop"`
+        to keep waiting without re-issuing the step. `pause` is special:
+        it bypasses the session lock so it can interrupt a step / wait
+        in flight from another tool call. Returns the new stop location
+        (or program output if the debuggee terminated)."""
+        params: list = []
+        if action != "pause":
+            params = [timeout_s]
+        return _format(await sess._call(action, params))
+
+    # --- Inspection ---------------------------------------------------
+
+    @mcp.tool(description="Evaluate one or more expressions in the stopped frame.")
+    async def inspect(expressions: list[str]) -> str:
+        """Evaluate each expression against the current stopped frame
+        and return the results formatted as 'expr = value' lines. THIS
+        EXECUTES ARBITRARY PYTHON in the debuggee process — use only
+        when the user has authorized inspection of the running program."""
+        return _format(await sess._call("inspect", list(expressions)))
+
+    @mcp.tool(description="Read the contents of a source file.")
+    async def read_source(file_path: str) -> str:
+        """Return the contents of `file_path` on the local filesystem
+        (resolved to an absolute path). Use to see source around a
+        stop location reported by `control` or `stack_trace`."""
+        return _format(await sess._call("get_source", [file_path]))
+
+    @mcp.tool(description="Show the current stack trace.")
+    async def stack_trace() -> str:
+        """Return the call stack at the current stop, with the active
+        frame marked with `*`. Use `inspect` to read locals from the
+        active frame; switch frames with stack navigation if the tdb
+        server exposes it (not currently part of this MCP surface)."""
+        return _format(await sess._call("get_stack_trace", []))
+
+    @mcp.tool(
+        description="Report whether the debuggee is stopped, running, or terminated."
+    )
+    async def status() -> str:
+        """Return one of: 'running', 'terminated', or 'stopped (<reason>)
+        at <file>:<line>'. Cheap call — use to confirm session state
+        before issuing other tools."""
+        return _format(await sess._call("status", []))
+
+    @mcp.tool(description="Drain captured stdout/stderr from the debuggee.")
+    async def get_output() -> str:
+        """Return and clear all stdout/stderr captured since the last
+        drain. Output is also folded into the return value of `control`
+        when the program terminates or stops; this tool is for peeking
+        without stepping."""
+        return _format(await sess._call("get_output", []))
+
+    # --- Breakpoints --------------------------------------------------
+
+    @mcp.tool(description="Set a breakpoint at 'file:line', with optional condition.")
+    async def set_breakpoint(
+        spec: str,
+        condition: str | None = None,
+        hit_condition: str | None = None,
+    ) -> str:
+        """`spec` is 'file.py:42'. `condition` is a Python expression
+        that must evaluate truthy for the breakpoint to fire.
+        `hit_condition` is an integer (or expression) gating on hit
+        count. Breakpoints snap to the nearest logical-statement start;
+        the response reports the move if any."""
+        params: list = [spec]
+        if condition is not None:
+            params.append(condition)
+            if hit_condition is not None:
+                params.append(hit_condition)
+        elif hit_condition is not None:
+            params.extend(["", hit_condition])
+        return _format(await sess._call("set_breakpoint", params))
+
+    @mcp.tool(description="Remove the breakpoint at 'file:line'.")
+    async def remove_breakpoint(spec: str) -> str:
+        return _format(await sess._call("remove_breakpoint", [spec]))
+
+    @mcp.tool(description="List all active breakpoints.")
+    async def list_breakpoints() -> str:
+        return _format(await sess._call("list_breakpoints", []))
+
+    # --- Differentiators: threads / tasks / processes / wait_graph ---
+
+    @mcp.tool(description="List threads or inspect one (stack + locals).")
+    async def threads(thread_id: int | None = None) -> str:
+        """No `thread_id` → list every thread with `id: name` and `*`
+        marking the current one. With `thread_id` → return that
+        thread's stack frames and locals."""
+        if thread_id is None:
+            return _format(await sess._call("list_threads", []))
+        return _format(await sess._call("inspect_thread", [thread_id]))
+
+    @mcp.tool(description="List asyncio tasks or inspect one.")
+    async def tasks(task_name: str | None = None) -> str:
+        """No `task_name` → list every task with state and what it's
+        awaiting. With `task_name` → return that task's stack and
+        locals. Pair with `wait_graph` to diagnose hangs."""
+        if task_name is None:
+            return _format(await sess._call("list_tasks", []))
+        return _format(await sess._call("inspect_task", [task_name]))
+
+    @mcp.tool(description="List child processes (multiprocessing) or inspect one.")
+    async def processes(name_or_pid: str | None = None) -> str:
+        """No `name_or_pid` → list every tracked child process. With
+        `name_or_pid` → return that process's metadata. tdb attaches
+        to children via debugpy's subProcess mechanism."""
+        if name_or_pid is None:
+            return _format(await sess._call("list_processes", []))
+        return _format(await sess._call("inspect_process", [name_or_pid]))
+
+    @mcp.tool(
+        description=(
+            "Show asyncio task wait-graph and any deadlock cycles "
+            "— the 'why is my program hung?' tool."
+        )
+    )
+    async def wait_graph() -> str:
+        """Returns blocked tasks with their awaiting target and
+        identified holders, plus any deadlock cycles. The single best
+        tool for diagnosing async hangs from an agent."""
+        return _format(await sess._call("wait_graph", []))
+
+    return mcp
+
+
+def main() -> None:
+    """Entry point for `tdb-mcp` / `python -m tdb.mcp`. Starts FastMCP
+    on stdio — control returns when the client disconnects."""
+    logging.basicConfig(level=logging.WARNING)
+    mcp = build_mcp()
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tdb/mcp/server.py
+++ b/src/tdb/mcp/server.py
@@ -78,7 +78,7 @@ def build_mcp(session: McpSession | None = None) -> FastMCP:
         instructions=(
             "tdb is a Python debugger driven via DAP. Use `debug_launch` "
             "or `debug_attach` to start a session, `control` to step / "
-            "continue / pause, and the `inspect` / stack / variable "
+            "continue / pause, and the `inspect` / `stack_trace` / `threads` / `tasks` / `processes` "
             "tools to examine state at a stopped frame. `control` and "
             "`wait_for_stop` return the sentinel 'still running — call "
             "pause or wait again' on timeout; respond with `control "

--- a/src/tdb/mcp/server.py
+++ b/src/tdb/mcp/server.py
@@ -1,6 +1,6 @@
 """FastMCP server exposing tdb as a Model Context Protocol tool surface.
 
-15 curated tools (not 26 auto-generated) so the agent's tool list stays
+16 curated tools (not 26 auto-generated) so the agent's tool list stays
 small and focused. Tool wrappers translate kwargs → JSON-RPC `params`
 list and call through `McpSession._call`, which preserves the HTTP
 dispatcher's lock policy — `pause` bypasses `session_lock` so an agent

--- a/src/tdb/mcp/session.py
+++ b/src/tdb/mcp/session.py
@@ -1,0 +1,205 @@
+"""Owns a single tdb debug session for the MCP server process.
+
+One MCP server process serves one stdio client, which drives one debug
+session at a time. This class is the third in-process consumer of
+`RpcHandlers` (after the TUI and FastAPI server); it mirrors the
+launch / attach sequence in `server.runner.run_headless` minus the
+uvicorn part (FastMCP owns the event loop instead).
+
+Tool wrappers in `tdb.mcp.server` call `_call(action, params)` to
+dispatch through `RpcHandlers.dispatch_table()`. The dispatcher's lock
+policy — including the `pause` bypass — is preserved here so MCP
+agents have the same interrupt semantics as HTTP clients.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from tdb._timeouts import DAP_INITIALIZED, DAP_STOP_ON_ENTRY
+from tdb.dap.types import SourceBreakpoint
+from tdb.server.app import NO_LOCK_ACTIONS
+from tdb.server.event_handler import ServerEventHandler
+from tdb.server.handlers import ControllerRef, RpcHandlers
+from tdb.server.rpc_types import RpcResponse
+from tdb.session.controller import DebugController
+
+log = logging.getLogger(__name__)
+
+
+class McpSession:
+    """One debug session, lazily created by `launch()` or `attach()`.
+
+    Before either is called, `_call` returns a clear "no session" error
+    so the agent gets actionable guidance instead of an AttributeError.
+    """
+
+    def __init__(self) -> None:
+        self._controller: DebugController | None = None
+        self._handler: ServerEventHandler | None = None
+        self._handlers: RpcHandlers | None = None
+
+    @property
+    def is_active(self) -> bool:
+        return (
+            self._handlers is not None
+            and self._controller is not None
+            and not self._controller.state.is_terminated
+        )
+
+    @property
+    def handlers(self) -> RpcHandlers | None:
+        return self._handlers
+
+    async def launch(
+        self,
+        program: str,
+        args: list[str] | None = None,
+        cwd: str | None = None,
+        stop_on_entry: bool = False,
+        just_my_code: bool = True,
+        python: str | None = None,
+        breakpoints: list[tuple[str, int]] | None = None,
+    ) -> str:
+        """Start a debug session on a local program. Returns a status
+        line summarizing where the debuggee landed (entry or first
+        stop). Errors if a session is already active — call `quit`
+        first to start a new one."""
+        if self.is_active:
+            return (
+                "A debug session is already active. Call `quit` before "
+                "starting a new one."
+            )
+
+        self._build_handlers()
+        assert self._controller is not None and self._handler is not None
+
+        # Mirror server/runner.py::run_headless. config persists across
+        # restart in the HTTP server path; MCP is simpler — no restart
+        # surface yet — so we just load step_mode and move on.
+        from tdb.persist import load_config
+
+        self._controller.step_mode = load_config().step_mode
+
+        self._apply_cli_breakpoints(breakpoints)
+
+        await self._controller.start(
+            program=program,
+            args=args,
+            cwd=cwd or str(Path.cwd()),
+            stop_on_entry=stop_on_entry,
+            just_my_code=just_my_code,
+            python=python,
+        )
+        return await self._finish_initialize(stop_on_entry=stop_on_entry)
+
+    async def attach(
+        self,
+        host: str,
+        port: int,
+        breakpoints: list[tuple[str, int]] | None = None,
+        path_mappings: list[tuple[str, str]] | None = None,
+    ) -> str:
+        """Attach to a remote debugpy server. `path_mappings` is
+        forwarded to debugpy's `pathMappings` for bidirectional path
+        translation (see `dap/client.py::attach`)."""
+        if self.is_active:
+            return (
+                "A debug session is already active. Call `quit` before "
+                "attaching to a new one."
+            )
+
+        self._build_handlers()
+        assert self._controller is not None
+
+        self._apply_cli_breakpoints(breakpoints)
+
+        await self._controller.remote_attach(
+            host=host,
+            port=port,
+            path_mappings=path_mappings,
+        )
+        # Remote-attach produces a stopped event via the pre-arm pause
+        # in controller.do_configure — same flow run_headless uses.
+        return await self._finish_initialize(stop_on_entry=True, remote=(host, port))
+
+    async def quit(self) -> str:
+        """Tear down the current session. Safe to call when no session
+        is active — returns a benign message in that case."""
+        if self._controller is None:
+            return "No active debug session."
+        try:
+            await self._controller.stop()
+        except Exception:
+            log.exception("Error stopping controller on quit")
+        self._controller = None
+        self._handler = None
+        self._handlers = None
+        return "Session stopped."
+
+    async def _call(self, action: str, params: list) -> RpcResponse:
+        """Dispatch an action through RpcHandlers with the same lock
+        policy as the HTTP dispatcher — `pause` (and any other entry
+        in NO_LOCK_ACTIONS) bypasses `session_lock` so it can interrupt
+        an in-flight blocking step / continue / wait_for_stop."""
+        if self._handlers is None:
+            return RpcResponse.error(
+                "No active debug session. Call `debug_launch` or `debug_attach` first."
+            )
+        table = self._handlers.dispatch_table()
+        fn = table.get(action)
+        if fn is None:
+            return RpcResponse.error(f"Unknown action: {action}")
+        try:
+            if action in NO_LOCK_ACTIONS:
+                return await fn(params)
+            async with self._handlers.session_lock:
+                return await fn(params)
+        except Exception as e:
+            log.exception("MCP action '%s' failed", action)
+            return RpcResponse.error(str(e))
+
+    # --- internals ----------------------------------------------------
+
+    def _build_handlers(self) -> None:
+        self._handler = ServerEventHandler()
+        self._controller = DebugController(self._handler)
+        self._handlers = RpcHandlers(ControllerRef(self._controller), self._handler)
+
+    def _apply_cli_breakpoints(self, breakpoints: list[tuple[str, int]] | None) -> None:
+        if not breakpoints or self._controller is None:
+            return
+        for bp_path, bp_line in breakpoints:
+            bps = self._controller.state.breakpoints.get(bp_path, [])
+            if not any(bp.line == bp_line for bp in bps):
+                bps.append(SourceBreakpoint(line=bp_line))
+                self._controller.state.breakpoints[bp_path] = bps
+
+    async def _finish_initialize(
+        self,
+        stop_on_entry: bool,
+        remote: tuple[str, int] | None = None,
+    ) -> str:
+        """Mirror run_headless: wait for `initialized`, send
+        configurationDone, then optionally wait for the first stop
+        (stop_on_entry or remote-attach pre-arm pause)."""
+        assert self._controller is not None and self._handler is not None
+        await asyncio.wait_for(
+            self._handler.initialized_event.wait(), timeout=DAP_INITIALIZED
+        )
+        await self._controller.do_configure()
+
+        if stop_on_entry:
+            stopped = await self._handler.wait_for_stop(timeout=DAP_STOP_ON_ENTRY)
+            if not stopped:
+                return (
+                    f"Session started but no stop arrived within "
+                    f"{DAP_STOP_ON_ENTRY:.0f}s."
+                )
+            await self._controller.fetch_stop_info()
+            loc, line = self._controller.state.get_stop_location()
+            tag = f"attached to {remote[0]}:{remote[1]}" if remote else "launched"
+            return f"Session {tag}; stopped at {loc}:{line}"
+        return "Session launched; debuggee is running."

--- a/src/tdb/server/app.py
+++ b/src/tdb/server/app.py
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 # any other RPC: it sends a DAP pause request and waits on the
 # controller's own stopped-event, which is the only state it mutates;
 # that mutation already races safely with DAP event callbacks.
-_NO_LOCK_ACTIONS = frozenset({"pause"})
+NO_LOCK_ACTIONS = frozenset({"pause"})
 
 
 def create_app(handlers: RpcHandlers) -> FastAPI:
@@ -51,7 +51,7 @@ def create_app(handlers: RpcHandlers) -> FastAPI:
         if action_fn is None:
             return RpcResponse.error(f"Unknown action: {request.action}")
         try:
-            if request.action in _NO_LOCK_ACTIONS:
+            if request.action in NO_LOCK_ACTIONS:
                 return await action_fn(request.params)
             async with handlers.session_lock:
                 return await action_fn(request.params)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -230,6 +230,39 @@ def test_doc_text_flag_default_false(tmp_path):
     assert args.doc_text is False
 
 
+def test_mcp_flag_short_circuits_program_check():
+    """--mcp owns its own lifecycle (sessions come from the agent's
+    debug_launch tool); no program argument is needed on the CLI."""
+    args = parse_args(["--mcp"])
+    assert args.mcp is True
+    assert args.program is None
+
+
+def test_mcp_flag_default_false(tmp_path):
+    prog = tmp_path / "x.py"
+    prog.write_text("\n")
+    args = parse_args([str(prog)])
+    assert args.mcp is False
+
+
+def test_main_dispatches_to_mcp_runner(monkeypatch):
+    """`tdb --mcp` must route to the MCP entry point, not to the TUI
+    or headless server. Equivalent to `python -m tdb.mcp`."""
+    called: list[bool] = []
+
+    def _fake_mcp_main():
+        called.append(True)
+
+    import tdb.mcp.server as mcp_server
+
+    monkeypatch.setattr(mcp_server, "main", _fake_mcp_main)
+
+    from tdb.cli import main as cli_main
+
+    cli_main(["--mcp"])
+    assert called == [True]
+
+
 def test_version_flag_prints_and_exits(capsys):
     with pytest.raises(SystemExit) as exc:
         parse_args(["--version"])

--- a/tests/unit/test_mcp_session.py
+++ b/tests/unit/test_mcp_session.py
@@ -1,0 +1,185 @@
+"""In-process unit tests for McpSession.
+
+McpSession is the third in-process consumer of RpcHandlers (after the
+TUI and the FastAPI/HTTP server). These tests pin its responsibilities:
+
+  - Before launch/attach: tool calls surface a clear "no session"
+    error instead of an AttributeError.
+  - When a session is active: `_call` dispatches through the same
+    RpcHandlers.dispatch_table() the HTTP server uses, including the
+    NO_LOCK_ACTIONS bypass (so `pause` can interrupt a long step).
+  - `quit` is idempotent and lets a fresh launch/attach happen
+    afterward in the same MCP process.
+
+We avoid spawning a debugpy subprocess by stitching a fake DAPClient
++ controller into the McpSession after construction — same pattern as
+test_rpc_handlers.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tdb.dap.types import SourceBreakpoint, Thread
+from tdb.mcp.session import McpSession
+from tdb.server.event_handler import ServerEventHandler
+from tdb.server.handlers import ControllerRef, RpcHandlers
+from tdb.session.controller import DebugController
+from tdb.session.state import SessionPhase
+
+
+# --- Fakes / helpers ----------------------------------------------------
+
+
+class _FakeDAPClient:
+    """Minimal surface — same shape as test_rpc_handlers._FakeDAPClient."""
+
+    def __init__(self) -> None:
+        self.set_breakpoints_calls: list[tuple[str, list[SourceBreakpoint]]] = []
+        self._threads: list[Thread] = []
+
+    async def set_breakpoints(self, source_path, breakpoints):
+        self.set_breakpoints_calls.append((source_path, list(breakpoints)))
+        return []
+
+    async def threads(self) -> list[Thread]:
+        return list(self._threads)
+
+
+def _attach_fake_session(sess: McpSession) -> None:
+    """Pretend launch() completed: stitch in a fake controller +
+    handlers so `_call` can dispatch without a real debug session."""
+    eh = ServerEventHandler()
+    controller = DebugController(eh)
+    controller.client = _FakeDAPClient()
+    controller.state.transition_to(SessionPhase.STOPPED)
+    sess._controller = controller
+    sess._handler = eh
+    sess._handlers = RpcHandlers(ControllerRef(controller), eh)
+
+
+# --- No-session guard ---------------------------------------------------
+
+
+async def test_call_before_launch_returns_no_session_error():
+    sess = McpSession()
+    rsp = await sess._call("status", [])
+    assert rsp.success is False
+    assert "no active debug session" in rsp.value.lower()
+    # Recovery hint must name BOTH lifecycle tools so the agent isn't
+    # left guessing which one to use.
+    assert "debug_launch" in rsp.value
+    assert "debug_attach" in rsp.value
+
+
+async def test_is_active_false_before_launch():
+    sess = McpSession()
+    assert sess.is_active is False
+
+
+async def test_quit_is_idempotent_with_no_session():
+    sess = McpSession()
+    msg = await sess.quit()
+    assert "no active" in msg.lower()
+
+
+# --- Dispatch + lock policy ---------------------------------------------
+
+
+async def test_call_dispatches_through_handlers():
+    sess = McpSession()
+    _attach_fake_session(sess)
+    rsp = await sess._call("status", [])
+    assert rsp.success is True
+    assert "stopped" in rsp.value or "unknown" in rsp.value
+
+
+async def test_call_rejects_unknown_action():
+    sess = McpSession()
+    _attach_fake_session(sess)
+    rsp = await sess._call("bogus", [])
+    assert rsp.success is False
+    assert "unknown action" in rsp.value.lower()
+
+
+async def test_pause_bypasses_session_lock():
+    """Regression mirror of the HTTP dispatcher test: hold the lock
+    (simulating an in-flight `control(action="continue")`), then call
+    `pause` and a non-bypassed action concurrently. Pause must come
+    back; the other must block on the lock — that's the proof the
+    bypass is what made pause go through."""
+    sess = McpSession()
+    _attach_fake_session(sess)
+    assert sess._handlers is not None
+
+    async with sess._handlers.session_lock:
+        pause_rsp = await asyncio.wait_for(sess._call("pause", []), timeout=1.0)
+        assert pause_rsp.success is True
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(sess._call("status", []), timeout=0.2)
+
+
+async def test_call_serializes_non_bypassed_actions():
+    """Two `status` calls in flight must serialize through session_lock.
+    The second one waits until the first releases — proves we still
+    hold the lock for everything outside NO_LOCK_ACTIONS."""
+    sess = McpSession()
+    _attach_fake_session(sess)
+    assert sess._handlers is not None
+
+    order: list[str] = []
+    gate = asyncio.Event()
+
+    original_status = sess._handlers.action_status
+
+    async def _slow_status(params):
+        order.append("start")
+        await gate.wait()
+        order.append("end")
+        return await original_status(params)
+
+    sess._handlers.action_status = _slow_status  # type: ignore[assignment]
+
+    t1 = asyncio.create_task(sess._call("status", []))
+    await asyncio.sleep(0.01)
+    t2 = asyncio.create_task(sess._call("status", []))
+    await asyncio.sleep(0.01)
+    # Only the first call should be inside the slow handler.
+    assert order == ["start"]
+    gate.set()
+    await asyncio.gather(t1, t2)
+    # Both calls ran; serialization preserved (no interleaving).
+    assert order == ["start", "end", "start", "end"]
+
+
+# --- is_active transitions ---------------------------------------------
+
+
+async def test_is_active_true_after_fake_attach():
+    sess = McpSession()
+    _attach_fake_session(sess)
+    assert sess.is_active is True
+
+
+async def test_is_active_false_after_terminated():
+    sess = McpSession()
+    _attach_fake_session(sess)
+    assert sess._controller is not None
+    sess._controller.state.transition_to(SessionPhase.TERMINATED)
+    assert sess.is_active is False
+
+
+async def test_launch_rejects_when_already_active():
+    sess = McpSession()
+    _attach_fake_session(sess)
+    msg = await sess.launch(program="anything.py")
+    assert "already active" in msg.lower()
+
+
+async def test_attach_rejects_when_already_active():
+    sess = McpSession()
+    _attach_fake_session(sess)
+    msg = await sess.attach(host="localhost", port=15678)
+    assert "already active" in msg.lower()

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -1,0 +1,164 @@
+"""Schema-level tests for the MCP tool surface.
+
+The agent's first interaction with tdb-mcp is the tool list and the
+parameter schemas. Pin both: name set, count, that every tool has a
+description, and that the consolidated `control` action enumerates
+exactly the actions the dispatch table supports.
+
+Behavior tests for individual tools live in test_mcp_session.py
+(driving McpSession._call directly) — those would be redundant here
+since the tool wrappers are thin translations into _call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tdb.mcp.server import _format, _parse_breakpoints, _parse_path_mappings, build_mcp
+from tdb.mcp.session import McpSession
+from tdb.server.rpc_types import RpcResponse
+
+
+# --- Tool registration --------------------------------------------------
+
+
+EXPECTED_TOOL_NAMES = {
+    # Lifecycle (3)
+    "debug_launch",
+    "debug_attach",
+    "quit",
+    # Control (1, consolidates 6 dispatch actions)
+    "control",
+    # Inspection (5)
+    "inspect",
+    "read_source",
+    "stack_trace",
+    "status",
+    "get_output",
+    # Breakpoints (3)
+    "set_breakpoint",
+    "remove_breakpoint",
+    "list_breakpoints",
+    # Differentiators (4)
+    "threads",
+    "tasks",
+    "processes",
+    "wait_graph",
+}
+
+
+@pytest.fixture
+def mcp_tools():
+    mcp = build_mcp(session=McpSession())
+    return asyncio.run(mcp.list_tools())
+
+
+def test_expected_tool_set(mcp_tools):
+    """Pin the curated tool surface so adding/removing a tool is a
+    visible decision in code review. Auto-generating one MCP tool per
+    dispatch-table action (26 of them) was explicitly rejected — the
+    agent's tool list should stay small and focused."""
+    names = {t.name for t in mcp_tools}
+    assert names == EXPECTED_TOOL_NAMES
+
+
+def test_every_tool_has_a_description(mcp_tools):
+    """Agents pick tools from descriptions, not from inferring intent
+    from names. A missing description silently degrades tool-selection
+    quality — fail loudly here instead."""
+    for t in mcp_tools:
+        assert t.description, f"tool {t.name!r} has no description"
+
+
+def test_control_enumerates_every_supported_action(mcp_tools):
+    """`control` consolidates 6 dispatch-table actions behind one
+    tool. Its action Literal must match exactly what RpcHandlers
+    dispatches — drift here would mean MCP exposes / hides actions
+    the HTTP API does not."""
+    control = next(t for t in mcp_tools if t.name == "control")
+    action_enum = set(control.inputSchema["properties"]["action"]["enum"])
+    assert action_enum == {
+        "continue",
+        "next",
+        "step_in",
+        "step_out",
+        "pause",
+        "wait_for_stop",
+    }
+
+
+def test_control_default_timeout_is_30s(mcp_tools):
+    """30s default matches Fable's recommendation: short enough that
+    an agent polling a runaway program gets a 'still running' return
+    promptly, long enough that normal step+stop completes in one call."""
+    control = next(t for t in mcp_tools if t.name == "control")
+    assert control.inputSchema["properties"]["timeout_s"]["default"] == 30.0
+
+
+# --- _format ------------------------------------------------------------
+
+
+def test_format_success_returns_value():
+    assert _format(RpcResponse.ok("at file.py:42")) == "at file.py:42"
+
+
+def test_format_success_with_empty_value_returns_ok():
+    """RpcResponse.ok() (no value) returns "" — agents shouldn't see
+    a blank string and assume failure; surface a benign 'ok'."""
+    assert _format(RpcResponse.ok()) == "ok"
+
+
+def test_format_error_prefixes_with_error_keyword():
+    """The 'still running' sentinel is a SUCCESS — agents distinguish
+    success/error by the 'Error:' prefix, not by parsing the message."""
+    rendered = _format(RpcResponse.error("not authorized"))
+    assert rendered.startswith("Error:")
+    assert "not authorized" in rendered
+
+
+# --- _parse_breakpoints -------------------------------------------------
+
+
+def test_parse_breakpoints_none_returns_none():
+    assert _parse_breakpoints(None) is None
+
+
+def test_parse_breakpoints_empty_returns_none():
+    assert _parse_breakpoints([]) is None
+
+
+def test_parse_breakpoints_splits_file_and_line():
+    assert _parse_breakpoints(["foo.py:42", "bar/baz.py:7"]) == [
+        ("foo.py", 42),
+        ("bar/baz.py", 7),
+    ]
+
+
+def test_parse_breakpoints_handles_windows_drive_letter():
+    """Last-colon split — drive letter survives intact."""
+    assert _parse_breakpoints(["C:/proj/foo.py:42"]) == [("C:/proj/foo.py", 42)]
+
+
+def test_parse_breakpoints_rejects_missing_colon():
+    with pytest.raises(ValueError, match="file:line"):
+        _parse_breakpoints(["no-colon-here"])
+
+
+# --- _parse_path_mappings -----------------------------------------------
+
+
+def test_parse_path_mappings_none_returns_none():
+    assert _parse_path_mappings(None) is None
+
+
+def test_parse_path_mappings_normalizes_json_arrays_to_tuples():
+    """JSON wire format is array-of-arrays; the DAP client wants
+    tuples. Normalize at the MCP boundary."""
+    assert _parse_path_mappings(
+        [["/local/a", "/remote/a"], ["/local/b", "/remote/b"]]
+    ) == [
+        ("/local/a", "/remote/a"),
+        ("/local/b", "/remote/b"),
+    ]

--- a/tests/unit/test_rpc_handlers.py
+++ b/tests/unit/test_rpc_handlers.py
@@ -707,6 +707,6 @@ async def test_dispatcher_pause_bypasses_session_lock(handlers):
 def test_no_lock_actions_constant_includes_pause():
     """The bypass list is a small, deliberate surface. Pin its contents
     so adding a new bypass becomes a visible decision in code review."""
-    from tdb.server.app import _NO_LOCK_ACTIONS
+    from tdb.server.app import NO_LOCK_ACTIONS
 
-    assert _NO_LOCK_ACTIONS == frozenset({"pause"})
+    assert NO_LOCK_ACTIONS == frozenset({"pause"})


### PR DESCRIPTION
Three ways to invoke:
- tdb-mcp (dedicated script entry from pyproject.toml)
- tdb --mcp (added to the main CLI)
- python -m tdb.mcp (module form)