### PR TITLE
source_analysis.py had incorrect logic for parsing match statements

### DIFF
--- a/src/tdb/__init__.py
+++ b/src/tdb/__init__.py
@@ -1,6 +1,6 @@
 from tdb.breakpoint_hook import breakpoint
 from tdb.post_mortem import exception_hook
 
-__version__ = "0.1.4"
+__version__ = "0.1.5b"
 
 __all__ = ["breakpoint", "exception_hook"]

--- a/src/tdb/source_analysis.py
+++ b/src/tdb/source_analysis.py
@@ -121,8 +121,11 @@ def _walk(node: ast.AST, out: list[tuple[int, int]]) -> None:
         out.append((dec.lineno, dec.end_lineno or dec.lineno))
 
     if isinstance(node, _COMPOUND_STMT_TYPES):
-        out.append(_header_range(node, node.body))
-        for sublist in _all_suites(node):
+        # ast.Match has no `body` — its suites live in `cases` — so
+        # derive the header end from the first suite whatever its name.
+        suites = list(_all_suites(node))
+        out.append(_header_range(node, suites[0] if suites else []))
+        for sublist in suites:
             for child in sublist:
                 _walk(child, out)
     elif isinstance(node, ast.ExceptHandler):
@@ -130,7 +133,14 @@ def _walk(node: ast.AST, out: list[tuple[int, int]]) -> None:
         for child in node.body:
             _walk(child, out)
     elif hasattr(ast, "match_case") and isinstance(node, ast.match_case):
-        out.append(_header_range(node, node.body))
+        # match_case carries no lineno of its own — its pattern does.
+        # The header is the `case <pattern> [if guard]:` line(s).
+        start = node.pattern.lineno
+        if node.body:
+            end = node.body[0].lineno - 1
+        else:
+            end = node.pattern.end_lineno or start
+        out.append((start, max(start, end)))
         for child in node.body:
             _walk(child, out)
     elif isinstance(node, ast.stmt):
@@ -149,7 +159,13 @@ def _header_range(
     """
     start = node.lineno  # type: ignore[attr-defined]
     if body:
-        end = body[0].lineno - 1  # type: ignore[attr-defined]
+        first = body[0]
+        # A Match node's first suite is `cases`, whose match_case
+        # elements have no lineno; their pattern does.
+        first_line = getattr(first, "lineno", None)
+        if first_line is None:
+            first_line = first.pattern.lineno
+        end = first_line - 1
     else:
         end = node.end_lineno or start  # type: ignore[attr-defined]
     return (start, max(start, end))

--- a/tests/unit/test_source_analysis.py
+++ b/tests/unit/test_source_analysis.py
@@ -87,6 +87,58 @@ def test_try_except_finally():
     assert find_step_unit(6, units) == (6, 6)
 
 
+def test_match_statement_header_cases_and_bodies():
+    # Regression: ast.Match has no `body` attribute (suites live in
+    # `cases`); compute_step_units used to crash with AttributeError on
+    # any real match statement.
+    units = _units("""\
+        match command:
+            case "go":
+                move()
+                log()
+            case _:
+                stop()
+        after = True
+        """)
+    assert find_step_unit(1, units) == (1, 1)  # match header
+    assert find_step_unit(2, units) == (2, 2)  # case "go":
+    assert find_step_unit(3, units) == (3, 3)  # move()
+    assert find_step_unit(4, units) == (4, 4)  # log()
+    assert find_step_unit(5, units) == (5, 5)  # case _:
+    assert find_step_unit(6, units) == (6, 6)  # stop()
+    assert find_step_unit(7, units) == (7, 7)  # after = True
+
+
+def test_match_with_multiline_subject():
+    units = _units("""\
+        match build(
+            arg,
+        ):
+            case _:
+                pass
+        """)
+    # Header spans the multi-line subject up to the first case.
+    assert find_step_unit(1, units) == (1, 3)
+    assert find_step_unit(4, units) == (4, 4)
+    assert find_step_unit(5, units) == (5, 5)
+
+
+def test_match_inside_function():
+    units = _units("""\
+        def handler(arg_type):
+            match arg_type:
+                case int():
+                    return 1
+                case _:
+                    return 0
+        """)
+    assert find_step_unit(1, units) == (1, 1)
+    assert find_step_unit(2, units) == (2, 2)
+    assert find_step_unit(3, units) == (3, 3)
+    assert find_step_unit(4, units) == (4, 4)
+    assert find_step_unit(6, units) == (6, 6)
+
+
 def test_function_def_header_separate_from_body():
     units = _units("""\
         def foo():


### PR DESCRIPTION
target code that caused traceback with `tdb main.py`, then 'n' on first line
```python
# main.py
from my_module import MyClass
print("ok")
```
```python
# my_module.py
from dataclasses import dataclass
@dataclass
class MyClass(Missing):
    pass
def _ex(arg):
    match arg:
        case _:
            pass
```