### PR TITLE
Multi language dap

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,15 @@ interactive evaluation of expressions in the current scope:
 
 Variable values set here are reflected in the running code.
 
+### Cut / Paste
+
+Expression for the Evaluate Console are often copied from the Code View.
+Doing this in `tdb` differs from traditional terminal behavior, because `textual` applications
+capture mouse events for their own use.
+
+Instead, hold the `Shift` key while performing your conventional cut/paste keystrokes or mouse
+operation to get the expected behavior.
+
 ### Console Output
 
 The Console View captures stdout (normal text) and stderr (red text) from the debuggee

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 `textual-debugger` (the package) provides `tdb` (the command-line tool and module),
 a full-featured terminal-based debugger for Python and other languages
 with a Debug Adapter Protocol (DAP) implementation. C and C++ support (via
-`lldb-dap` or `gdb`) is built in.
+`gdb` or `lldb-dap`) is built in.
 
 `tdb` is built with [textual](https://github.com/Textualize/textual) and speaks
 DAP to a pluggable debug adapter: [debugpy](https://github.com/microsoft/debugpy)
 (the engine behind VS Code's Python debugger) for Python,
-[lldb-dap](https://lldb.llvm.org/resources/lldbdap.html) or
-[GDB's DAP mode](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Debugger-Adapter-Protocol.html)
+[GDB's DAP mode](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Debugger-Adapter-Protocol.html) or
+[lldb-dap](https://lldb.llvm.org/resources/lldbdap.html)
 for compiled code. It provides a rich interactive interface for stepping through
 code, inspecting variables, managing breakpoints, and evaluating expressions in
 complex programs.
@@ -24,7 +24,7 @@ MIT License.  Copyright 2026 by Al Danial.
 `tdb`:
 
 - debugs multiple languages through the Debug Adapter Protocol: Python (via `debugpy`,
-the richest feature set) and C/C++ (via `lldb-dap` or `gdb -i dap`), with the language
+the richest feature set) and C/C++ (via `gdb -i dap` or `lldb-dap`), with the language
 auto-detected from the target (ref. [Multi-Language Debugging](#multi-language-debugging)).
 
 - supports debugging of synchronous, asynchronous, multi-threaded, and multi-process Python code.
@@ -114,11 +114,11 @@ tdb my_program.py
 tdb my_program.py arg1 arg2
 
 # debug a C/C++ (or other native) executable built with -g.  The ELF/Mach-O/PE
-# binary is auto-detected and debugged through lldb-dap
+# binary is auto-detected and debugged through GDB's DAP mode (GDB >= 14)
 tdb ./myprog arg1 arg2
 
-# same, but using GDB's DAP implementation (GDB >= 14) instead of lldb-dap
-tdb --adapter gdb ./myprog
+# same, but using lldb-dap (LLVM >= 17) instead of gdb
+tdb --adapter lldb-dap ./myprog
 
 # force the language when auto-detection can't tell (e.g. an extensionless script)
 tdb --lang python ./mytool
@@ -172,7 +172,7 @@ languages are supported out of the box:
 | Language | Adapter(s) | How to get the adapter | Feature level |
 |----------|------------|------------------------|---------------|
 | Python | `debugpy` (default) | installed with `textual-debugger` | everything in this README |
-| C / C++ (any native binary) | `lldb-dap` (default), `gdb` (alternate) | `lldb-dap` ships with LLVM ≥ 17 (e.g. `apt install lldb`); `gdb -i dap` requires GDB ≥ 14 | core debugging: breakpoints, stepping, stack, variables, evaluate console |
+| C / C++ (any native binary) | `gdb` (default), `lldb-dap` (alternate) | `gdb -i dap` requires GDB ≥ 14; `lldb-dap` ships with LLVM ≥ 17 (e.g. `apt install lldb`) | core debugging: breakpoints, stepping, stack, variables, evaluate console |
 
 ### Language detection and selection
 
@@ -186,7 +186,7 @@ The language is auto-detected from the debug target:
 5. Anything else produces an error naming the `--lang` override.
 
 `--lang` forces the language; `--adapter` picks a non-default adapter within
-it (`tdb --lang cpp --adapter gdb ./myprog`).
+it (`tdb --lang cpp --adapter lldb-dap ./myprog`).
 
 > **Migration note:** extensionless Python scripts without a `python` shebang
 > were previously assumed to be Python; they now require `--lang python`.
@@ -201,7 +201,7 @@ non-standard location, or change a language's default adapter, add to
 ```json
 {
   "adapters": {"lldb-dap": "/opt/llvm/bin/lldb-dap"},
-  "default_adapters": {"cpp": "gdb"}
+  "default_adapters": {"cpp": "lldb-dap"}
 }
 ```
 
@@ -229,8 +229,9 @@ currently ignored for non-Python targets.
 - Stack frames pointing into system libraries often have no source on disk;
   the Code View shows a `<Could not read …>` placeholder while the stack,
   variables, and evaluate console remain fully usable.
-- `lldb-dap` debugs GCC-built binaries fine (DWARF is compiler-neutral), but
-  GDB's libstdc++ pretty-printing (via `--adapter gdb`) is more complete.
+- GDB (the default adapter) has the most complete libstdc++
+  pretty-printing. `lldb-dap` (via `--adapter lldb-dap`) also debugs
+  GCC-built binaries fine — DWARF is compiler-neutral.
 - **GDB evaluate-console quirk:** GDB's DAP treats REPL input as CLI
   commands, so evaluate expressions with an explicit `print`, e.g.
   `print x` rather than bare `x` (bare `x` collides with GDB's
@@ -931,7 +932,7 @@ usage: tdb [-h] [-v] [-r [HOST:]PORT] [--cwd CWD] [--no-stop-on-entry]
 | `--python PATH` | Python interpreter for the debuggee (Python targets only) |
 | `--pv` | Shorthand for --python .venv/bin/python |
 | `--lang LANGUAGE` | Debuggee language (`python`, `cpp`); default: auto-detect from the target |
-| `--adapter ADAPTER` | Debug adapter within the language (e.g. `--lang cpp --adapter gdb`); default: the language's standard adapter |
+| `--adapter ADAPTER` | Debug adapter within the language (e.g. `--lang cpp --adapter lldb-dap`); default: the language's standard adapter |
 | `--no-just-my-code` | Step into stdlib/site-packages code instead of skipping it
   (default: skipped). On uncaught exceptions, the crash modal always shows the full traceback
   including library frames, regardless of this flag. |
@@ -957,7 +958,7 @@ On Windows, it uses `%APPDATA%\tdb\`.
 Adapter-related keys in `config.json`: `adapters` maps an adapter id to an
 executable path (`{"adapters": {"lldb-dap": "/opt/llvm/bin/lldb-dap"}}`), and
 `default_adapters` picks a language's default adapter
-(`{"default_adapters": {"cpp": "gdb"}}`).
+(`{"default_adapters": {"cpp": "lldb-dap"}}`).
 
 Breakpoints are saved on exit and restored when debugging a program in the same
 directory. Each project's breakpoints are independent.
@@ -979,7 +980,7 @@ fires as expected.
 
 - [textual](https://github.com/Textualize/textual) : TUI framework
 - [debugpy](https://github.com/microsoft/debugpy) : Debug Adapter Protocol implementation for Python
-- [lldb-dap](https://lldb.llvm.org/resources/lldbdap.html) / [gdb](https://sourceware.org/gdb/) : optional, user-installed DAP adapters for C/C++
+- [gdb](https://sourceware.org/gdb/) / [lldb-dap](https://lldb.llvm.org/resources/lldbdap.html) : optional, user-installed DAP adapters for C/C++
 - [pygments](https://pygments.org/) : Syntax highlighting
 - [FastAPI](https://fastapi.tiangolo.com/) + [uvicorn](https://www.uvicorn.org/) : JSON-RPC server
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,8 +3,8 @@
 Use this skill when you need to understand runtime behavior of code -- variable values, control flow, why a condition is or isn't met, what a function actually returns, or why an exception occurs. This is faster and more reliable than inserting print/logging statements.
 
 `tdb` debugs Python (via debugpy, full feature set) and C/C++ or any native
-binary built with `-g` (via `lldb-dap`, or `gdb -i dap` with
-`adapter="gdb"`). The language is auto-detected from the target: `.py` →
+binary built with `-g` (via `gdb -i dap`, or `lldb-dap` with
+`adapter="lldb-dap"`). The language is auto-detected from the target: `.py` →
 Python, ELF/Mach-O/PE executable → C/C++.
 
 ## When to use this
@@ -47,15 +47,16 @@ The server owns the debug session — do not also start `tdb --headless`.
 Multi-language notes:
 - `debug_launch` auto-detects the language from `program` — pass a compiled
   binary directly (`debug_launch(program="/abs/path/prog")` debugs it via
-  lldb-dap). `lang="cpp"` forces it; `adapter="gdb"` selects GDB. The
-  `python` param is only valid for Python debuggees (errors otherwise).
+  GDB's DAP mode). `lang="cpp"` forces it; `adapter="lldb-dap"` selects
+  lldb-dap instead. The `python` param is only valid for Python debuggees
+  (errors otherwise).
 - `tasks`, `processes`, and `wait_graph` are Python-only; for other
   languages they return a structured "not supported" error. `threads`
   works everywhere.
-- **GDB only:** `inspect`/`evaluate` expressions go through GDB's CLI —
-  prefix with `print` (`inspect(expressions=["print x"])`); bare `x`
-  collides with GDB's examine-memory command. lldb-dap evaluates bare
-  expressions directly.
+- **GDB (the default C/C++ adapter):** `inspect`/`evaluate` expressions
+  go through GDB's CLI — prefix with `print`
+  (`inspect(expressions=["print x"])`); bare `x` collides with GDB's
+  examine-memory command. lldb-dap evaluates bare expressions directly.
 - If breakpoints in a C/C++ file never bind, the binary likely lacks debug
   info — rebuild with `-g -O0`.
 
@@ -102,7 +103,8 @@ If the script needs a specific virtualenv:
 ```
 
 For a C/C++ binary (compiled with `-g`), the same headless mode works — the
-language is auto-detected; add `--adapter gdb` to use GDB instead of lldb-dap:
+language is auto-detected; add `--adapter lldb-dap` to use lldb-dap instead
+of GDB:
 ```bash
 .venv/bin/python -m tdb --headless /path/to/binary arg1 &
 ```

--- a/src/tdb/__init__.py
+++ b/src/tdb/__init__.py
@@ -1,6 +1,6 @@
 from tdb.breakpoint_hook import breakpoint
 from tdb.post_mortem import exception_hook
 
-__version__ = "0.2.0b"
+__version__ = "0.2.0"
 
 __all__ = ["breakpoint", "exception_hook"]

--- a/src/tdb/cli.py
+++ b/src/tdb/cli.py
@@ -25,7 +25,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="tdb",
         description="A multi-language DAP debugger with a textual TUI "
-        "(Python via debugpy, C/C++ via lldb-dap/gdb).",
+        "(Python via debugpy, C/C++ via gdb/lldb-dap).",
     )
     parser.add_argument(
         "-v",
@@ -96,7 +96,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="ADAPTER",
         help="Debug adapter to use within the language (e.g. `--lang cpp "
-        "--adapter gdb`). Default: the language's standard adapter.",
+        "--adapter lldb-dap`). Default: the language's standard adapter.",
     )
     parser.add_argument(
         "--keybindings",

--- a/src/tdb/languages/cpp.py
+++ b/src/tdb/languages/cpp.py
@@ -1,9 +1,9 @@
 """The C/C++ language profile.
 
-Default adapter: lldb-dap (ships with LLVM >= 17; debugs GCC- and
-clang-built binaries alike — DWARF is compiler-neutral). Alternate:
-`gdb -i dap` (GDB >= 14) via GdbDapAdapter, selected via
-`--adapter gdb`.
+Default adapter: `gdb -i dap` (GDB >= 14) via GdbDapAdapter.
+Alternate: lldb-dap (ships with LLVM >= 17; debugs GCC- and
+clang-built binaries alike — DWARF is compiler-neutral), selected
+via `--adapter lldb-dap`.
 
 Core-DAP capabilities only: no statement stepping (no C++ source
 model), no task inspection, no child-process tracking.
@@ -75,7 +75,7 @@ class LldbDapAdapter(AdapterSpec):
 class GdbDapAdapter(AdapterSpec):
     """GDB's built-in DAP interpreter (`gdb -i dap`, GDB >= 14).
 
-    Alternate C++ adapter: GDB's libstdc++ pretty-printers are more
+    Default C++ adapter: GDB's libstdc++ pretty-printers are more
     complete than LLDB's, which matters for heavily GCC codebases.
     """
 
@@ -133,7 +133,7 @@ def build_cpp_profile(
         "lldb-dap": LldbDapAdapter,
         "gdb": GdbDapAdapter,
     }
-    adapter_id = adapter or "lldb-dap"
+    adapter_id = adapter or "gdb"
     if adapter_id not in adapters:
         raise LanguageNotSupportedError(
             f"unknown adapter {adapter_id!r} for cpp "

--- a/tests/integration/test_cpp_session.py
+++ b/tests/integration/test_cpp_session.py
@@ -61,15 +61,16 @@ def test_registry_detects_compiled_binary_as_cpp(cpp_binary):
 
 
 # --- live-session fixtures/helpers, copied+adapted from
-# --- test_dap_session.py: controller built with profile=build_cpp_profile(),
-# --- _launch() calls ctrl.start(program=binary, ...) with no python= kwarg.
+# --- test_dap_session.py: controller built with profile=build_cpp_profile(
+# --- adapter="lldb-dap"), _launch() calls ctrl.start(program=binary, ...)
+# --- with no python= kwarg.
 
 
 @pytest.fixture
 async def session():
     """(controller, handler) pair with guaranteed teardown."""
     handler = ServerEventHandler()
-    ctrl = DebugController(handler, profile=build_cpp_profile())
+    ctrl = DebugController(handler, profile=build_cpp_profile(adapter="lldb-dap"))
     yield ctrl, handler
     try:
         await asyncio.wait_for(ctrl.stop(), timeout=WAIT)

--- a/tests/unit/test_cpp_profile.py
+++ b/tests/unit/test_cpp_profile.py
@@ -11,7 +11,7 @@ from tdb.languages import registry
 def test_profile_shape():
     p = build_cpp_profile()
     assert p.id == "cpp"
-    assert p.adapter.id == "lldb-dap"
+    assert p.adapter.id == "gdb"
     assert p.presentation.lexer == "cpp"
     assert p.capabilities.compute_step_units is None
     assert p.capabilities.child_process_strategy is None
@@ -29,8 +29,8 @@ def test_command_uses_explicit_executable():
 
 
 def test_adapter_paths_override_reaches_default_adapter():
-    p = build_cpp_profile(adapter_paths={"lldb-dap": "/opt/lldb-dap"})
-    assert p.adapter.command() == ["/opt/lldb-dap"]
+    p = build_cpp_profile(adapter_paths={"gdb": "/opt/gdb"})
+    assert p.adapter.command() == ["/opt/gdb", "-i", "dap"]
 
 
 def test_command_missing_executable_hints_install(monkeypatch):
@@ -89,6 +89,12 @@ def test_unknown_cpp_adapter_rejected():
 def test_gdb_adapter_selectable():
     p = build_cpp_profile(adapter="gdb")
     assert p.adapter.id == "gdb"
+    assert p.id == "cpp"  # same language side
+
+
+def test_lldb_adapter_selectable():
+    p = build_cpp_profile(adapter="lldb-dap")
+    assert p.adapter.id == "lldb-dap"
     assert p.id == "cpp"  # same language side
 
 


### PR DESCRIPTION
- make `gdb` the default C/C++ adapter
- document how to cut/copy/paste text in a textual app