### PR TITLE
Tab completion fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ tdb --lang python ./mytool
 # program runs to the first breakpoint)
 tdb -k 20 -k 35 -k module.py:14 my_program.py arg1 arg2
 
+# run straight to line 20 without saving the breakpoint for future
+# sessions (-t is -k minus the persistence)
+tdb -t 20 my_program.py
+
 # use a specific virtualenv
 tdb --python /path/to/venv/bin/python my_program.py
 
@@ -936,6 +940,7 @@ usage: tdb [-h] [-v] [-r [HOST:]PORT] [--cwd CWD] [--no-stop-on-entry]
 | `--local-root PATH` | Local directory containing a copy of remote code (repeat to mirror multiple trees). Pair with `--remote-root`; counts must match. Required when `-k` sets a breakpoint against a remote debuggee whose code lives at a different path. |
 | `--remote-root PATH` | Remote directory matched to `--local-root` (same CLI position via `zip()`). |
 | `-k`, `--breakpoint FILE:LINE|LINE` | Set a breakpoint (may be repeated). Passing `-k` implies `--no-stop-on-entry` so the program runs straight to the first breakpoint. |
+| `-t`, `--to-line FILE:LINE|LINE` | Like `-k`, but the breakpoint is not saved to the breakpoints file — it just takes you to that spot in the code for this session (may be repeated). |
 | `--no-stop-on-entry` | Do not pause at the first line (default: stop on entry; automatic when `-k` is given) |
 | `--cwd DIR` | Working directory for the debuggee |
 | `--python PATH` | Python interpreter for the debuggee (Python targets only) |
@@ -970,7 +975,9 @@ executable path (`{"adapters": {"lldb-dap": "/opt/llvm/bin/lldb-dap"}}`), and
 (`{"default_adapters": {"cpp": "lldb-dap"}}`).
 
 Breakpoints are saved on exit and restored when debugging a program in the same
-directory. Each project's breakpoints are independent.
+directory. Each project's breakpoints are independent. Breakpoints set with
+`-t`/`--to-line` are the exception: they behave like `-k` breakpoints during
+the session but are never saved.
 
 **Step mode** (`step_mode` in `config.json`) controls how `n` (step over) and `s` (step
 into) handle multi-line source statements:

--- a/src/tdb/app.py
+++ b/src/tdb/app.py
@@ -195,7 +195,7 @@ class TdbApp(_AppMessageRoutes, App):
         python: str | None = None,
         terminal: str | None = None,
         config: TdbConfig | None = None,
-        cli_breakpoints: list[tuple[str, int]] | None = None,
+        cli_breakpoints: list[tuple[str, int, bool]] | None = None,
         attach_host: str | None = None,
         attach_port: int | None = None,
         path_mappings: list[tuple[str, str]] | None = None,
@@ -341,13 +341,7 @@ class TdbApp(_AppMessageRoutes, App):
         if saved:
             self.controller.state.breakpoints = saved
         # Add CLI breakpoints (additive, won't duplicate)
-        for bp_path, bp_line in self._cli_breakpoints:
-            bps = self.controller.state.breakpoints.get(bp_path, [])
-            if not any(bp.line == bp_line for bp in bps):
-                from tdb.dap.types import SourceBreakpoint
-
-                bps.append(SourceBreakpoint(line=bp_line))
-                self.controller.state.breakpoints[bp_path] = bps
+        self.controller.state.install_cli_breakpoints(self._cli_breakpoints)
         # Update visuals
         if self.controller.state.breakpoints:
             all_bps = self.controller.state.breakpoints

--- a/src/tdb/app.py
+++ b/src/tdb/app.py
@@ -1148,17 +1148,23 @@ class TdbApp(_AppMessageRoutes, App):
     async def on_evaluate_console_completion_requested(
         self, message: EvaluateConsole.CompletionRequested
     ) -> None:
+        eval_console = self.query_one("#eval-console", EvaluateConsole)
         try:
-            items = await self.controller.active_client.completions(
+            client = self.controller.active_client
+            # Same resolution as evaluate: current_frame_id may be synthetic
+            # (async-task navigation, traceback parse) and debugpy rejects
+            # unknown frame ids.
+            frame_id = await self.controller.resolve_evaluate_frame_id(client)
+            items = await client.completions(
                 text=message.text,
                 column=message.column,
-                frame_id=self.controller.state.current_frame_id,
+                frame_id=frame_id,
             )
             completions = [(item.label, item.text) for item in items]
-            eval_console = self.query_one("#eval-console", EvaluateConsole)
             eval_console.apply_completion(message.text, completions)
-        except Exception:
+        except Exception as e:
             log.exception("Error fetching completions")
+            eval_console.show_error(f"<completion failed: {e}>")
 
     # --- Menu handlers ---
 

--- a/src/tdb/cli.py
+++ b/src/tdb/cli.py
@@ -171,6 +171,16 @@ def build_parser() -> argparse.ArgumentParser:
         "at line 1.",
     )
     parser.add_argument(
+        "-t",
+        "--to-line",
+        action="append",
+        default=[],
+        metavar="FILE:LINE|LINE",
+        help="Like -k/--breakpoint, but the breakpoint is not saved to "
+        "the breakpoints file: it just takes you to that spot in the "
+        "code for this session (may be repeated).",
+    )
+    parser.add_argument(
         "--server-port",
         type=int,
         default=8150,
@@ -208,12 +218,12 @@ def _apply_flag_implications(args: argparse.Namespace) -> None:
     """Fill in derived flags from primary ones.
 
     - `stop_on_entry` is derived from `--no-stop-on-entry`.
-    - `-k` implies `--no-stop-on-entry`: a CLI breakpoint means "run
-       to here", not "pause at line 1".
+    - `-k` / `-t` imply `--no-stop-on-entry`: a CLI breakpoint means
+       "run to here", not "pause at line 1".
     - `--headless` implies `--server` (headless IS the server).
     """
     args.stop_on_entry = not args.no_stop_on_entry
-    if args.breakpoint:
+    if args.breakpoint or args.to_line:
         args.stop_on_entry = False
     if args.headless:
         args.server = True
@@ -393,45 +403,52 @@ def _parse_breakpoints(
     args: argparse.Namespace,
     parser: argparse.ArgumentParser,
 ) -> None:
-    """Parse `-k FILE:LINE | LINE` specs into `[(abs_path, line), ...]`.
+    """Parse `-k` / `-t` `FILE:LINE | LINE` specs into `[(abs_path, line), ...]`.
 
     A bare LINE targets `args.program` (rejected for remote-attach
     because there's no local program to anchor on). After parsing, the
-    list still needs `_snap_breakpoints` to align lines to logical
+    lists still need `_snap_breakpoints` to align lines to logical
     statement starts.
     """
-    parsed_bps: list[tuple[str, int]] = []
     local_roots = [local for local, _ in args.path_mappings]
-    for spec in args.breakpoint:
-        if ":" in spec:
-            file_part, line_part = spec.rsplit(":", 1)
-            try:
-                line = int(line_part)
-            except ValueError:
-                parser.error(f"Invalid line number in breakpoint: {spec}")
-            bp_path = _resolve_breakpoint_file(file_part, local_roots)
-            if bp_path is None:
-                if local_roots:
-                    roots_str = ", ".join(local_roots)
+
+    def parse_spec_list(specs: list[str], flag: str) -> list[tuple[str, int]]:
+        parsed_bps: list[tuple[str, int]] = []
+        for spec in specs:
+            if ":" in spec:
+                file_part, line_part = spec.rsplit(":", 1)
+                try:
+                    line = int(line_part)
+                except ValueError:
+                    parser.error(f"Invalid line number in breakpoint: {spec}")
+                bp_path = _resolve_breakpoint_file(file_part, local_roots)
+                if bp_path is None:
+                    if local_roots:
+                        roots_str = ", ".join(local_roots)
+                        parser.error(
+                            f"Breakpoint file not found: {file_part} "
+                            f"(searched: cwd, {roots_str})"
+                        )
+                    else:
+                        parser.error(f"Breakpoint file not found: {file_part}")
+                parsed_bps.append((str(bp_path), line))
+            else:
+                try:
+                    line = int(spec)
+                except ValueError:
                     parser.error(
-                        f"Breakpoint file not found: {file_part} "
-                        f"(searched: cwd, {roots_str})"
+                        f"Invalid breakpoint (expected FILE:LINE or LINE): {spec}"
                     )
-                else:
-                    parser.error(f"Breakpoint file not found: {file_part}")
-            parsed_bps.append((str(bp_path), line))
-        else:
-            try:
-                line = int(spec)
-            except ValueError:
-                parser.error(f"Invalid breakpoint (expected FILE:LINE or LINE): {spec}")
-            if not args.program:
-                parser.error(
-                    f"Bare-line breakpoint -k {spec} requires a program "
-                    "(not allowed with --remote-attach)"
-                )
-            parsed_bps.append((args.program, line))
-    args.breakpoint = parsed_bps
+                if not args.program:
+                    parser.error(
+                        f"Bare-line breakpoint {flag} {spec} requires a program "
+                        "(not allowed with --remote-attach)"
+                    )
+                parsed_bps.append((args.program, line))
+        return parsed_bps
+
+    args.breakpoint = parse_spec_list(args.breakpoint, "-k")
+    args.to_line = parse_spec_list(args.to_line, "-t")
 
 
 def _snap_breakpoints(args: argparse.Namespace) -> None:
@@ -446,24 +463,28 @@ def _snap_breakpoints(args: argparse.Namespace) -> None:
 
     from tdb.source_analysis import snap_breakpoint
 
-    snapped_bps: list[tuple[str, int]] = []
-    for bp_path, line in args.breakpoint:
-        snapped = snap_breakpoint(bp_path, line)
-        if snapped is None:
-            print(
-                f"warning: -k {bp_path}:{line} has no logical statement "
-                f"at or before that line; dropping breakpoint",
-                file=sys.stderr,
-            )
-            continue
-        if snapped != line:
-            print(
-                f"warning: -k {bp_path}:{line} is not the start of a "
-                f"logical statement; moved to line {snapped}",
-                file=sys.stderr,
-            )
-        snapped_bps.append((bp_path, snapped))
-    args.breakpoint = snapped_bps
+    def snap_list(bps: list[tuple[str, int]], flag: str) -> list[tuple[str, int]]:
+        snapped_bps: list[tuple[str, int]] = []
+        for bp_path, line in bps:
+            snapped = snap_breakpoint(bp_path, line)
+            if snapped is None:
+                print(
+                    f"warning: {flag} {bp_path}:{line} has no logical statement "
+                    f"at or before that line; dropping breakpoint",
+                    file=sys.stderr,
+                )
+                continue
+            if snapped != line:
+                print(
+                    f"warning: {flag} {bp_path}:{line} is not the start of a "
+                    f"logical statement; moved to line {snapped}",
+                    file=sys.stderr,
+                )
+            snapped_bps.append((bp_path, snapped))
+        return snapped_bps
+
+    args.breakpoint = snap_list(args.breakpoint, "-k")
+    args.to_line = snap_list(args.to_line, "-t")
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -486,6 +507,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     _resolve_language(args, parser)
     _parse_breakpoints(args, parser)
     _snap_breakpoints(args)
+    # Merged (path, line, persist) list consumed by the TUI and headless
+    # runner: -k breakpoints are saved on exit, -t ones are session-only.
+    args.cli_bps = [(p, ln, True) for p, ln in args.breakpoint] + [
+        (p, ln, False) for p, ln in args.to_line
+    ]
     return args
 
 
@@ -629,7 +655,7 @@ def _run_headless(args: argparse.Namespace) -> None:
             just_my_code=not args.no_just_my_code,
             python=args.python,
             port=args.server_port,
-            cli_breakpoints=args.breakpoint,
+            cli_breakpoints=args.cli_bps,
             attach_host=args.attach_host,
             attach_port=args.attach_port,
             path_mappings=args.path_mappings or None,
@@ -659,7 +685,7 @@ def _run_tui(args: argparse.Namespace) -> None:
         python=args.python,
         terminal=args.terminal,
         config=config,
-        cli_breakpoints=args.breakpoint,
+        cli_breakpoints=args.cli_bps,
         attach_host=args.attach_host,
         attach_port=args.attach_port,
         path_mappings=args.path_mappings,

--- a/src/tdb/dap/types.py
+++ b/src/tdb/dap/types.py
@@ -48,6 +48,9 @@ class SourceBreakpoint:
     hit_condition: str | None = None
     log_message: str | None = None
     enabled: bool = True  # tdb-local flag; not part of DAP wire format
+    # tdb-local flag; not part of DAP wire format. False for -t/--to-line
+    # breakpoints, which are excluded from breakpoints.json on save.
+    persist: bool = True
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"line": self.line}

--- a/src/tdb/mcp/session.py
+++ b/src/tdb/mcp/session.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from tdb._timeouts import DAP_INITIALIZED, DAP_STOP_ON_ENTRY
-from tdb.dap.types import SourceBreakpoint
 from tdb.server.app import NO_LOCK_ACTIONS
 from tdb.server.event_handler import ServerEventHandler
 from tdb.server.handlers import ControllerRef, RpcHandlers
@@ -215,11 +214,9 @@ class McpSession:
     def _apply_cli_breakpoints(self, breakpoints: list[tuple[str, int]] | None) -> None:
         if not breakpoints or self._controller is None:
             return
-        for bp_path, bp_line in breakpoints:
-            bps = self._controller.state.breakpoints.get(bp_path, [])
-            if not any(bp.line == bp_line for bp in bps):
-                bps.append(SourceBreakpoint(line=bp_line))
-                self._controller.state.breakpoints[bp_path] = bps
+        self._controller.state.install_cli_breakpoints(
+            [(path, line, True) for path, line in breakpoints]
+        )
 
     async def _finish_initialize(
         self,

--- a/src/tdb/persist.py
+++ b/src/tdb/persist.py
@@ -41,16 +41,18 @@ def _encode_bps(
 ) -> dict[str, list[dict]]:
     out = {}
     for source_path, bps in breakpoints.items():
-        if bps:
-            out[source_path] = [
-                {
-                    "line": bp.line,
-                    "condition": bp.condition,
-                    "hit_condition": bp.hit_condition,
-                    "enabled": bp.enabled,
-                }
-                for bp in bps
-            ]
+        encoded = [
+            {
+                "line": bp.line,
+                "condition": bp.condition,
+                "hit_condition": bp.hit_condition,
+                "enabled": bp.enabled,
+            }
+            for bp in bps
+            if bp.persist
+        ]
+        if encoded:
+            out[source_path] = encoded
     return out
 
 

--- a/src/tdb/server/runner.py
+++ b/src/tdb/server/runner.py
@@ -30,7 +30,7 @@ async def run_headless(
     python: str | None = None,
     port: int = 8150,
     host: str = "127.0.0.1",
-    cli_breakpoints: list[tuple[str, int]] | None = None,
+    cli_breakpoints: list[tuple[str, int, bool]] | None = None,
     attach_host: str | None = None,
     attach_port: int | None = None,
     path_mappings: list[tuple[str, str]] | None = None,
@@ -57,13 +57,7 @@ async def run_headless(
 
     # Apply CLI breakpoints
     if cli_breakpoints:
-        from tdb.dap.types import SourceBreakpoint
-
-        for bp_path, bp_line in cli_breakpoints:
-            bps = controller.state.breakpoints.get(bp_path, [])
-            if not any(bp.line == bp_line for bp in bps):
-                bps.append(SourceBreakpoint(line=bp_line))
-                controller.state.breakpoints[bp_path] = bps
+        controller.state.install_cli_breakpoints(cli_breakpoints)
 
     # Start the debug session
     if is_remote:

--- a/src/tdb/session/state.py
+++ b/src/tdb/session/state.py
@@ -207,6 +207,21 @@ class DebugState:
 
     # --- Existing helper methods ---------------------------------------
 
+    def install_cli_breakpoints(self, cli_bps: list[tuple[str, int, bool]]) -> None:
+        """Add `-k` / `-t` CLI breakpoints to the session state.
+
+        Each entry is (abs_path, line, persist); `-t`/--to-line entries
+        carry persist=False so they never reach breakpoints.json. A
+        breakpoint already present at the same spot (e.g. restored from
+        a previous session) wins — it is neither duplicated nor
+        downgraded to transient.
+        """
+        for bp_path, bp_line, persist in cli_bps:
+            bps = self.breakpoints.get(bp_path, [])
+            if not any(bp.line == bp_line for bp in bps):
+                bps.append(SourceBreakpoint(line=bp_line, persist=persist))
+                self.breakpoints[bp_path] = bps
+
     def clear_frame_data(self) -> None:
         self.stack_frames.clear()
         self.scopes.clear()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -654,3 +654,53 @@ def test_breakpoint_relative_searches_local_roots_in_order(tmp_path):
         ]
     )
     assert args.breakpoint == [(str(src.resolve()), 5)]
+
+
+# --- -t / --to-line: like -k but not persisted -------------------------------
+
+
+def test_to_line_parsed_like_breakpoint(tmp_path):
+    prog = tmp_path / "x.py"
+    prog.write_text("a = 1\nb = 2\nc = 3\n")
+    args = parse_args([str(prog), "-t", f"{prog}:2", "-t", "3"])
+    assert args.to_line == [
+        (str(prog.resolve()), 2),
+        (str(prog.resolve()), 3),
+    ]
+    assert args.breakpoint == []
+
+
+def test_to_line_implies_no_stop_on_entry(tmp_path):
+    prog = tmp_path / "x.py"
+    prog.write_text("a = 1\n")
+    args = parse_args([str(prog), "-t", "1"])
+    assert args.stop_on_entry is False
+
+
+def test_to_line_snaps_to_statement_start(tmp_path, capsys):
+    prog = tmp_path / "x.py"
+    prog.write_text(
+        "a = 1\n"
+        "results = func(\n"  # line 2 (statement start)
+        "    1,\n"  # line 3 — sub-line
+        ")\n"
+    )
+    args = parse_args([str(prog), "-t", "3"])
+    assert args.to_line == [(str(prog.resolve()), 2)]
+    err = capsys.readouterr().err
+    assert "-t" in err and "moved to line 2" in err
+
+
+def test_to_line_bare_line_requires_program():
+    with pytest.raises(SystemExit):
+        parse_args(["--remote-attach", "5678", "-t", "10"])
+
+
+def test_cli_bps_merges_breakpoint_and_to_line_with_persist_flag(tmp_path):
+    prog = tmp_path / "x.py"
+    prog.write_text("a = 1\nb = 2\nc = 3\n")
+    args = parse_args([str(prog), "-k", "1", "-t", "2"])
+    assert args.cli_bps == [
+        (str(prog.resolve()), 1, True),
+        (str(prog.resolve()), 2, False),
+    ]

--- a/tests/unit/test_cli_breakpoint_install.py
+++ b/tests/unit/test_cli_breakpoint_install.py
@@ -1,0 +1,23 @@
+"""DebugState.install_cli_breakpoints: the single install path shared by
+the TUI (app.on_mount) and headless (run_headless) for -k / -t CLI
+breakpoints. -t entries are installed with persist=False; existing
+breakpoints at the same spot are never duplicated or downgraded."""
+
+from tdb.dap.types import SourceBreakpoint
+from tdb.session.state import DebugState
+
+
+def test_install_sets_persist_flag_per_entry():
+    state = DebugState()
+    state.install_cli_breakpoints([("/abs/x.py", 1, True), ("/abs/x.py", 2, False)])
+    bps = state.breakpoints["/abs/x.py"]
+    assert [(b.line, b.persist) for b in bps] == [(1, True), (2, False)]
+
+
+def test_install_does_not_duplicate_or_downgrade_existing():
+    state = DebugState()
+    state.breakpoints["/abs/x.py"] = [SourceBreakpoint(line=7)]
+    state.install_cli_breakpoints([("/abs/x.py", 7, False)])
+    bps = state.breakpoints["/abs/x.py"]
+    assert len(bps) == 1
+    assert bps[0].persist is True  # saved breakpoint stays persistent

--- a/tests/unit/test_completion_frame_resolution.py
+++ b/tests/unit/test_completion_frame_resolution.py
@@ -1,0 +1,77 @@
+"""Tab completion must resolve a live frame id the same way evaluate does
+(synthetic-frame fallback via resolve_evaluate_frame_id) and surface DAP
+errors in the evaluate console instead of dying silently."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from textual.widgets import RichLog
+
+from tdb.app import TdbApp
+from tdb.persist import TdbConfig
+from tdb.widgets.evaluate_console import EvaluateConsole
+
+SNAPSHOT = {
+    "version": 1,
+    "exception": {"type": "X", "message": "m", "traceback_text": "tb"},
+    "frames": [
+        {
+            "id": 1,
+            "filename": "/nonexistent/path/prog.py",
+            "lineno": 3,
+            "funcname": "boom",
+            "scopes": [{"name": "Locals", "variablesReference": 1001}],
+        }
+    ],
+    "variables": {"1001": []},
+}
+
+
+class _FakeClient:
+    def __init__(self, error: Exception | None = None):
+        self.calls: list[dict] = []
+        self._error = error
+
+    async def completions(self, text, column, frame_id=None):
+        self.calls.append({"text": text, "column": column, "frame_id": frame_id})
+        if self._error is not None:
+            raise self._error
+        return []
+
+
+def _fake_controller(client: _FakeClient, resolved_frame_id: int | None):
+    async def resolve(c):
+        assert c is client  # must resolve against the same client it queries
+        return resolved_frame_id
+
+    return SimpleNamespace(
+        active_client=client,
+        resolve_evaluate_frame_id=resolve,
+        # A stale id that must NOT be handed to DAP directly.
+        state=SimpleNamespace(current_frame_id=999),
+    )
+
+
+async def test_completion_uses_resolved_frame_id():
+    app = TdbApp(program="", config=TdbConfig(), post_mortem_snapshot=SNAPSHOT)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        client = _FakeClient()
+        app.controller = _fake_controller(client, resolved_frame_id=777)
+        msg = EvaluateConsole.CompletionRequested("x.", 3)
+        await app.on_evaluate_console_completion_requested(msg)
+        assert client.calls == [{"text": "x.", "column": 3, "frame_id": 777}]
+
+
+async def test_completion_error_surfaces_in_console():
+    app = TdbApp(program="", config=TdbConfig(), post_mortem_snapshot=SNAPSHOT)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        client = _FakeClient(error=RuntimeError("frame gone"))
+        app.controller = _fake_controller(client, resolved_frame_id=5)
+        msg = EvaluateConsole.CompletionRequested("x.", 3)
+        await app.on_evaluate_console_completion_requested(msg)
+        output = app.query_one("#eval-output", RichLog)
+        rendered = "\n".join(str(line) for line in output.lines)
+        assert "frame gone" in rendered

--- a/tests/unit/test_persist.py
+++ b/tests/unit/test_persist.py
@@ -198,3 +198,18 @@ def test_config_adapter_fields_round_trip(isolated_persist):
     TdbConfig = isolated_persist.TdbConfig
     cfg = TdbConfig(adapters={"gdb": "/usr/bin/gdb"})
     assert TdbConfig.from_dict(cfg.to_dict()).adapters == {"gdb": "/usr/bin/gdb"}
+
+
+def test_transient_breakpoints_not_saved(isolated_persist):
+    """-t breakpoints (persist=False) must never reach breakpoints.json."""
+    bps = {
+        "/abs/x.py": [
+            SourceBreakpoint(line=5),
+            SourceBreakpoint(line=9, persist=False),
+        ],
+        "/abs/only_transient.py": [SourceBreakpoint(line=1, persist=False)],
+    }
+    isolated_persist.save_breakpoints(bps, program="/abs/x.py")
+    loaded = isolated_persist.load_breakpoints(program="/abs/x.py")
+    assert [b.line for b in loaded["/abs/x.py"]] == [5]
+    assert "/abs/only_transient.py" not in loaded


### PR DESCRIPTION
Clean up tab completion logic.
New switch `-t` / `--to-line` that works like `-k` / `--breakpoint` except the breakpoint is not persisted.