### PR TITLE
fix: make CI green without system perl, and install perl in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@
 # docker run -it --rm tdb [args]
 
 FROM ghcr.io/astral-sh/uv:python3.14-alpine AS base
+# perl powers the Perl DAP adapter; without it the perl test suite
+# silently skips in CI (and one launch-preflight test used to fail).
+RUN apk add --no-cache perl
 RUN adduser -D appuser
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/tests/unit/test_perl_dap_server.py
+++ b/tests/unit/test_perl_dap_server.py
@@ -118,6 +118,22 @@ async def test_launch_failure_tears_down_session(tmp_path, monkeypatch):
 
     monkeypatch.setattr(server_mod, "PerlSession", StubSession)
 
+    # The failure under test is session.launch() raising AFTER the
+    # perl-version preflight passed. Stub the preflight subprocess so
+    # the test doesn't require a system perl (CI images may not have
+    # one) -- without this, a perl-less machine takes the "perl not
+    # usable" early-error path and the teardown never runs.
+    class StubPreflight:
+        returncode = 0
+
+        async def communicate(self):
+            return b"", b""
+
+    async def fake_exec(*args, **kwargs):
+        return StubPreflight()
+
+    monkeypatch.setattr(server_mod.asyncio, "create_subprocess_exec", fake_exec)
+
     reader = asyncio.StreamReader()
     writer = SinkWriter()
     server = PerlDapServer(reader, writer)


### PR DESCRIPTION
The workflow's docker test image (alpine) has no perl. All perl test files already skip cleanly in that case except one: test_launch_failure_tears_down_session exercises "session.launch() raised AFTER the preflight passed", but with no perl the version preflight short-circuits _on_launch with the "perl not usable" error first, so the stub session is never created and the teardown assertion fails. Stub the preflight subprocess so the test is independent of the machine's perl.

Also apk-add perl in the Docker base stage so CI actually runs the 43-test perl suite (real perl5db) instead of silently skipping it; the suite degrades gracefully when PadWalker isn't installed.

Verified with perl hidden from PATH: 861 passed, 43 skipped, 0 failed.