### PR TITLE
Perl BEGIN block fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 `textual-debugger` (the package) provides `tdb` (the command-line tool and module),
 a full-featured terminal-based debugger for Python and other languages
-with a Debug Adapter Protocol (DAP) implementation. C and C++ support (via
-`gdb` or `lldb-dap`) is built in.
+with a Debug Adapter Protocol (DAP) implementation.  In addition to Python,
+`tdb` comes with built-in support for
+- C and C++ (via `gdb` or `lldb-dap`)
+- Perl (via `perl -d`)
 
 `tdb` is built with [textual](https://github.com/Textualize/textual) and speaks
 DAP to a pluggable debug adapter: [debugpy](https://github.com/microsoft/debugpy)
@@ -255,6 +257,43 @@ hood, so it works with any Perl already on the system.
 ```bash
 tdb script.pl
 ```
+
+**Compile-time code (`BEGIN` blocks):** Perl runs `BEGIN` blocks — and the
+`use` statements that are themselves `BEGIN` blocks — while it is still
+*compiling* your program, before stock `perl5db` ever stops. `tdb` arms the
+debugger ahead of compilation so that code is debuggable too, which means the
+first stop is the first **compile-time** statement of your file (typically
+`use strict;` near the top) rather than the first runtime statement. Step from
+there and you land inside your `BEGIN` blocks, with the stack, variable and
+evaluate views working normally; the `Stack` view shows the frame as
+`main::BEGIN`. Stepping through a `use` line takes a few steps — the pragma's
+own compile-time work happens in between — but you are never dragged into
+another module's internals.
+
+Two consequences worth knowing:
+
+- **Breakpoints are deferred while your program compiles.** During the compile
+  phase Perl has only parsed part of your file, so its line table is
+  incomplete and a breakpoint can't be verified yet. `tdb` holds such requests
+  and applies them once compilation finishes. A breakpoint placed *inside* a
+  `BEGIN` block may therefore not fire on the first run — step into the block
+  from the initial stop instead.
+- **Startup is slower for large dependency graphs**, because the debugger is
+  active throughout compilation. A script with a big `use` tree takes
+  noticeably longer to reach its first stop under `tdb`.
+
+**`END` blocks** are entered with **step-in** (`s`). `next` and `continue` run
+straight past them to program termination, which is standard `perl5db`
+behavior, not a `tdb` limitation.
+
+**When your program dies:** an uncaught Perl error (`die`, or a fatal runtime
+error such as division by zero) opens the same error modal Python tracebacks
+get — the message, the call stack parsed from Perl's `at FILE line N.` /
+`... called at FILE line N` output, and Code View navigated to the failing
+line. This works for compile-time failures too, including a `die` inside a
+`BEGIN` block that aborts compilation. Press `e` in Code View to re-summon the
+last error. `tdb` also reports the debuggee's real exit status rather than
+assuming success.
 
 **Remote attach:** useful when the Perl process is already running (a long-
 lived service, a process started by something other than `tdb`) or lives on

--- a/README.md
+++ b/README.md
@@ -264,9 +264,10 @@ tdb script.pl
 debugger ahead of compilation so that code is debuggable too, which means the
 first stop is the first **compile-time** statement of your file (typically
 `use strict;` near the top) rather than the first runtime statement. Step from
-there and you land inside your `BEGIN` blocks, with the stack, variable and
-evaluate views working normally; the `Stack` view shows the frame as
-`main::BEGIN`. Stepping through a `use` line takes a few steps — the pragma's
+there and you land inside your `BEGIN` blocks, with the stack and evaluate
+views working normally (local variable listing is limited at a compile-time
+stop); the `Stack` view shows the frame as `main::BEGIN`. Stepping through a
+`use` line takes a few steps — the pragma's
 own compile-time work happens in between — but you are never dragged into
 another module's internals.
 

--- a/README.md
+++ b/README.md
@@ -276,9 +276,16 @@ Two consequences worth knowing:
 - **Breakpoints are deferred while your program compiles.** During the compile
   phase Perl has only parsed part of your file, so its line table is
   incomplete and a breakpoint can't be verified yet. `tdb` holds such requests
-  and applies them once compilation finishes. A breakpoint placed *inside* a
-  `BEGIN` block may therefore not fire on the first run — step into the block
-  from the initial stop instead.
+  and, while it single-steps through the rest of compilation, checks each
+  compile-time statement it lands on against them — so a breakpoint placed
+  *inside* a `BEGIN` block fires there directly, on the first run, without
+  needing to be stepped into by hand. Conditional breakpoints work the same
+  way at compile time; a condition that itself errors behaves exactly like a
+  bad condition at runtime — it does not fire. Two residual caveats: a
+  breakpoint on a non-statement line (the `BEGIN {` line itself, or a blank
+  line) never fires during the compile phase, since it's never actually
+  trapped as a statement; and `hitCondition` (break on the Nth hit) isn't
+  honored for a compile-time stop, only a plain `condition`.
 - **Startup is slower for large dependency graphs**, because the debugger is
   active throughout compilation. A script with a big `use` tree takes
   noticeably longer to reach its first stop under `tdb`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -56,6 +56,15 @@ Multi-language notes:
   program must be prepared with `Devel::TdbRemote` (`use Devel::TdbRemote;`
   first line, `listen()` + `wait_for_client()`) in place of
   `debugpy.listen()`/`wait_for_client()`. C/C++ has no attach mode.
+- **Perl stops during compilation.** A launched Perl debuggee's first stop is
+  the first *compile-time* statement of the program (usually `use strict;`
+  near the top), not the first runtime statement — this is what makes `BEGIN`
+  blocks steppable. Stepping from there enters them (`stack` reports the frame
+  as `main::BEGIN`). Two implications when scripting: a `set_breakpoint` issued
+  before compilation finishes is held and applied afterwards, so it comes back
+  unverified and a breakpoint *inside* a `BEGIN` block may not fire on the
+  first run (step into the block instead); and reaching your program's runtime
+  entry point takes a few extra `next`/`step_in` calls.
 - `tasks`, `processes`, and `wait_graph` remain Python-only; for other
   languages they return a structured "not supported" error. `threads`
   works everywhere.

--- a/SKILL.md
+++ b/SKILL.md
@@ -61,10 +61,14 @@ Multi-language notes:
   near the top), not the first runtime statement — this is what makes `BEGIN`
   blocks steppable. Stepping from there enters them (`stack` reports the frame
   as `main::BEGIN`). Two implications when scripting: a `set_breakpoint` issued
-  before compilation finishes is held and applied afterwards, so it comes back
-  unverified and a breakpoint *inside* a `BEGIN` block may not fire on the
-  first run (step into the block instead); and reaching your program's runtime
-  entry point takes a few extra `next`/`step_in` calls.
+  before compilation finishes is held and comes back unverified, but a
+  breakpoint *inside* a `BEGIN` block still fires on the first run — it's
+  checked against each compile-time statement as compilation proceeds, no
+  manual stepping needed (a condition on it that errors behaves like a bad
+  condition at runtime and does not fire; `hitCondition` isn't honored at
+  compile time; and a breakpoint on a non-statement line such as the
+  `BEGIN {` line itself never fires during the compile phase); and reaching
+  your program's runtime entry point takes a few extra `next`/`step_in` calls.
 - `tasks`, `processes`, and `wait_graph` remain Python-only; for other
   languages they return a structured "not supported" error. `threads`
   works everywhere.

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,0 @@
-remote attachment 
-
-# this works:  tdb -r PORT
-
-# this fails:  tdb -r PORT  file.py
-
-# need to be able to specify a file so that an additional breakpoint can be set

--- a/docs/superpowers/plans/2026-08-06-perl-errors-and-begin-blocks.md
+++ b/docs/superpowers/plans/2026-08-06-perl-errors-and-begin-blocks.md
@@ -381,16 +381,25 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 
 ---
 
-### Task 4: Report the debuggee's real exit code
+### Task 4: Report the debuggee's real exit code, and gate fatality on it
 
 **Files:**
 - Modify: `src/tdb/adapters/perl/server.py` (`_classify_and_emit_stop`'s `"?"` branch ~315-322; `_forward_output`'s `__eof__` branch ~292-296)
 - Modify: `src/tdb/adapters/perl/session.py` (expose the child's exit status)
-- Test: `tests/integration/test_perl_exit_code.py`
+- Modify: `src/tdb/languages/base.py`, `src/tdb/languages/errors.py`, `src/tdb/app_handlers/dap_events.py` (the exit-code gate below)
+- Test: `tests/integration/test_perl_exit_code.py`, `tests/unit/test_error_parsers.py` (extend)
 
-Today both termination routes hardcode `{"exitCode": 0}`, so a program that died is indistinguishable from a clean exit. Add a way to read the owned child's return code (launch mode only; attach has no owned child — keep `0` there) and report it.
+**Part 1 — real exit codes.** Today both termination routes hardcode `{"exitCode": 0}`, so a program that died is indistinguishable from a clean exit. Add a way to read the owned child's return code (launch mode only; attach has no owned child — keep `0` there) and report it.
 
 Note the child may not have reaped yet when perl5db parks at its "terminated" prompt: perl5db stays alive at a live prompt after the program ends. Wait for the process with a short bounded timeout (~2 s) and fall back to `0` rather than blocking the event loop.
+
+**Part 2 — replace Task 2's warning denylist with an exit-code gate.** Task 2 had to distinguish a fatal `die` from a non-fatal `warn` on a lone `... at FILE line N.` stderr line, and (with the plan's blessing) used a hardcoded denylist of five known warning prefixes. Both the implementer and the task reviewer flagged this as fragile: common warnings that are NOT on that list (`Deep recursion on subroutine`, `Subroutine x redefined`, `Name "main::x" used only once`, `Wide character in print`, and any bare user `warn "..."` call) would be misclassified as fatal, popping a spurious error modal on a clean run. Now that real exit codes exist, replace it with a deterministic signal:
+
+- Widen the seam to `parse_error(stderr: str, exit_code: int | None) -> ParsedError | None` on `Presentation`. Update `parse_python_error` to accept and ignore `exit_code` (its sentinel is unambiguous — do NOT gate the Python path on exit code; a program can print a caught traceback and still exit 0, and changing that is out of scope).
+- `parse_perl_error`: when `exit_code` is a non-`None` integer, fatality is exactly `exit_code != 0` — delete the prefix denylist from that path entirely. Keep the existing heuristic ONLY as the `exit_code is None` fallback (attach mode, or an exit code that never arrived), and say so in a comment.
+- `_check_stderr_traceback` must pass the exit code through. Find where the `exited` event's code is recorded (`on_exited` in `dap_events.py`; check whether `controller.state` or the event handler retains it) and thread it; if nothing retains it today, store it when `exited` arrives. Beware ordering: `terminated` and `exited` are separate events and `_check_stderr_traceback` runs on `terminated` — verify empirically which arrives first for both debugpy and the Perl adapter, and if `exited` can arrive later, wait for it the same bounded way `_wait_for_stderr_quiescent` already waits, or pass `None` and accept the fallback. State what you found in your report.
+
+Add unit tests pinning: a lone unlisted warning (`Deep recursion on subroutine "main::f" at /w/x.pl line 3.`) with `exit_code=0` returns `None`; the same text with `exit_code=255` parses as fatal; a real die with `exit_code=None` still parses via the fallback.
 
 - [ ] **Step 1: Write the failing test**
 

--- a/docs/superpowers/plans/2026-08-06-perl-errors-and-begin-blocks.md
+++ b/docs/superpowers/plans/2026-08-06-perl-errors-and-begin-blocks.md
@@ -1,0 +1,706 @@
+# Perl Error Modal + BEGIN-Block Debugging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Perl fatal errors surface in the same error modal Python errors do (message + call stack + Code View navigation), and Perl `BEGIN` blocks become steppable by stopping during the compile phase.
+
+**Architecture:** Two independent halves. (A) A new language-agnostic error-parsing seam on `Presentation` — `parse_error(stderr) -> ParsedError | None` — with the existing Python traceback parser moved behind it and a new Perl `die` parser added; `_check_stderr_traceback` and `_TracebackModal` become profile-driven. (B) A `Devel::TdbCompile` preload module, injected by the Perl session driver, that wraps `DB::DB` with a phase-aware file-filtered shim and arms `$DB::single` before the program is compiled, so the first stop lands on the first compile-time statement of the user's file; breakpoint application is deferred until the RUN phase because the line table is incomplete during compilation.
+
+**Tech Stack:** Python 3, perl5db (perl >= 5.18), textual, pytest.
+
+## Background — verified facts (do not re-derive)
+
+These were established empirically against perl 5.40.1 before this plan was written. Trust them.
+
+1. Perl `BEGIN` blocks run at compile time, **before** perl5db's first prompt, so tdb never sees them. This is documented perl5db behavior (`perldebug`, "Debugging Compile-Time Statements").
+2. Arming `$DB::single = 1` from a `-M`-preloaded module **does** make compile-time statements trap into `DB::DB`.
+3. Naively armed, `s` drags the user through `strict.pm` / `warnings.pm` internals. Wrapping `DB::DB` with a filter that (a) passes through once `${^GLOBAL_PHASE} ne 'START'` and (b) during START only traps when `(caller)[1] eq $target_file` produces exactly the wanted behavior: on `work/has_begin.pl` the stops are line 2 (`use strict`), line 3 (`use warnings`), then **line 7 (`my $a = 10;`) and line 8 (`my %b;`) inside the BEGIN block**.
+4. `helpers.pl` loads fine at a compile-time stop and `Devel::TdbHelper::location()` returns correct data there, reporting `sub: main::BEGIN`. So stack / scopes / variables / evaluate all work during the compile phase.
+5. **END blocks already work today** — no change needed. Verified through tdb's own adapter: `stepIn` from `clean2.pl:12` gives `:15 → :16 → :17` with `sub=main::END`. Only step-*in* enters them; `next`/`continue` skip to termination. This plan must not regress that.
+6. A Perl `die` (runtime **or** compile-time) does not produce any distinct perl5db stop — perl5db goes straight to its "Debugged program terminated" state. The error text reaches tdb only via the debuggee's **stderr pipe**, which the adapter already forwards with category `stderr`, so it is already in `TdbApp._stderr_buffer` when `on_terminated` runs.
+7. Real Perl error text to parse (from `work/has_begin.pl`):
+   ```
+   Illegal division by zero at /home/al/projects/tdbg/work/has_begin.pl line 10.
+    at /home/al/projects/tdbg/work/has_begin.pl line 10.
+   	main::BEGIN() called at /home/al/projects/tdbg/work/has_begin.pl line 11
+   	eval {...} called at /home/al/projects/tdbg/work/has_begin.pl line 11
+   BEGIN failed--compilation aborted at /home/al/projects/tdbg/work/has_begin.pl line 11.
+   ```
+   A plain runtime die is just the first line, e.g. `Illegal division by zero at /tmp/x.pl line 4.`
+8. During the compile phase the user's file is only **partially compiled**: `b <file>:<line>` on a later line answers `not breakable`. Hence Task 5's deferral.
+
+## Global Constraints
+
+- Run tests with `uv run pytest <paths> -q --no-cov` from `/home/al/projects/tdbg/work` (never bare `pytest`).
+- NEVER `git add -A`, `git add .`, or `git commit -a` — stage explicit paths only.
+- End every commit message with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Shell is zsh: avoid bare `*` globs and `==` tokens in test commands.
+- A formatter hook may rewrite files after Edit — if an anchor is missing, Read the file again.
+- Cross-platform: no POSIX-only path assumptions.
+- Perl code must stay compatible with perl >= 5.18 and pass `perl -c`.
+- Never change `helpers.pl`'s existing marker protocol (`TDB>>>{json}<<<TDB`) or bump `$PROTOCOL` without updating both ends.
+
+## File Structure
+
+- `src/tdb/languages/base.py` — MODIFY: add `ErrorFrame`, `ParsedError`, and `Presentation.parse_error`.
+- `src/tdb/languages/errors.py` — NEW: `parse_python_error`, `parse_perl_error`.
+- `src/tdb/languages/python.py`, `src/tdb/languages/perl.py` — MODIFY: wire the parsers into `Presentation`.
+- `src/tdb/app_handlers/dap_events.py` — MODIFY: `_check_stderr_traceback` becomes profile-driven.
+- `src/tdb/widgets/modals.py` — MODIFY: `_TracebackModal` takes its header instead of hardcoding Python's.
+- `src/tdb/adapters/perl/Devel/TdbCompile.pm` — NEW: the compile-phase shim.
+- `src/tdb/adapters/perl/session.py` — MODIFY: inject the preload; expose phase.
+- `src/tdb/adapters/perl/helpers.pl` — MODIFY: add `phase()` helper.
+- `src/tdb/adapters/perl/server.py` — MODIFY: defer breakpoints during compile phase; real exit code.
+- `README.md` — MODIFY: document both behaviors and their limitations.
+
+---
+
+### Task 1: Error-parsing seam + Python parser moved behind it
+
+**Files:**
+- Modify: `src/tdb/languages/base.py` (near `Presentation`, ~line 110)
+- Create: `src/tdb/languages/errors.py`
+- Modify: `src/tdb/languages/python.py` (its `Presentation(...)` construction)
+- Test: `tests/unit/test_error_parsers.py`
+
+**Interfaces produced** (Tasks 2-4 depend on these exact names):
+
+```python
+@dataclass(frozen=True)
+class ErrorFrame:
+    path: str
+    line: int
+    func: str          # "" when the language doesn't name one
+
+@dataclass(frozen=True)
+class ParsedError:
+    header: str        # modal's first line, e.g. "Traceback (most recent call last):"
+    message: str       # e.g. "ZeroDivisionError: division by zero"
+    frames: list[ErrorFrame]   # OUTERMOST-first (source order), same as Python prints
+
+# on Presentation:
+    parse_error: Callable[[str], "ParsedError | None"] | None = None
+```
+
+`parse_python_error(stderr: str) -> ParsedError | None` must reproduce today's behavior exactly: bail unless `"Traceback (most recent call last):"` is present; split on chained-traceback headers and use the LAST block; extract frames with the existing `_TB_FILE_RE` (`r'^\s*File "(.+)", line (\d+)(?:, in (.+))?'`, `re.MULTILINE`); derive the exception line with the existing "first non-indented line after the frames" heuristic. Move this logic out of `dap_events.py:206-295` — do not reimplement it from memory; copy it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/test_error_parsers.py
+"""Language-specific fatal-error parsers behind Presentation.parse_error."""
+
+from tdb.languages.errors import parse_python_error
+
+SIMPLE = '''Traceback (most recent call last):
+  File "/app/main.py", line 12, in <module>
+    boom()
+  File "/app/lib.py", line 5, in boom
+    return 1 / 0
+ZeroDivisionError: division by zero
+'''
+
+CHAINED = '''Traceback (most recent call last):
+  File "/app/a.py", line 2, in <module>
+    inner()
+ValueError: first
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/app/b.py", line 9, in <module>
+    outer()
+RuntimeError: second
+'''
+
+
+def test_returns_none_without_traceback():
+    assert parse_python_error("just some stderr noise\n") is None
+
+
+def test_parses_message_and_frames_in_source_order():
+    p = parse_python_error(SIMPLE)
+    assert p is not None
+    assert p.header == "Traceback (most recent call last):"
+    assert p.message == "ZeroDivisionError: division by zero"
+    assert [(f.path, f.line, f.func) for f in p.frames] == [
+        ("/app/main.py", 12, "<module>"),
+        ("/app/lib.py", 5, "boom"),
+    ]
+
+
+def test_chained_traceback_uses_last_block():
+    p = parse_python_error(CHAINED)
+    assert p is not None
+    assert p.message == "RuntimeError: second"
+    assert [f.path for f in p.frames] == ["/app/b.py"]
+
+
+def test_presentation_exposes_parser_for_python():
+    from tdb.languages import registry
+
+    profile = registry.resolve("python")
+    assert profile.presentation.parse_error is not None
+    assert profile.presentation.parse_error(SIMPLE) is not None
+
+
+def test_presentation_parse_error_defaults_to_none():
+    from tdb.languages.base import Presentation
+
+    assert Presentation().parse_error is None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/test_error_parsers.py -q --no-cov`
+Expected: FAIL — `ModuleNotFoundError: No module named 'tdb.languages.errors'`
+
+- [ ] **Step 3: Implement**
+
+Add `ErrorFrame`, `ParsedError` to `base.py` (near `Presentation`) and the `parse_error` field to `Presentation`. Create `errors.py` with `parse_python_error` carrying the moved logic. Wire `parse_error=parse_python_error` into the Python profile's `Presentation(...)`. Do NOT touch `dap_events.py` yet — that is Task 3.
+
+- [ ] **Step 4: Verify green**
+
+Run: `uv run pytest tests/unit/test_error_parsers.py tests/unit -q --no-cov`
+Expected: new tests pass; zero regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tdb/languages/base.py src/tdb/languages/errors.py src/tdb/languages/python.py tests/unit/test_error_parsers.py
+git commit -m "feat: language-agnostic error-parsing seam on Presentation
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Perl `die` parser
+
+**Files:**
+- Modify: `src/tdb/languages/errors.py`, `src/tdb/languages/perl.py`
+- Test: `tests/unit/test_error_parsers.py` (append)
+
+**Interfaces consumed:** `ErrorFrame`, `ParsedError` (Task 1).
+**Produces:** `parse_perl_error(stderr) -> ParsedError | None`, wired as the Perl profile's `parse_error`.
+
+Rules, derived from the real output in Background §7:
+- Detect a fatal error by the trailing-location form `... at <FILE> line <N>.` on the FIRST line of the error. Return `None` when no line matches — plain warnings such as `Use of uninitialized value in division (/) at x.pl line 10.` also match that shape, so only treat stderr as fatal when it also contains a `died`-shaped terminator: either the message is the last non-empty content, or a `BEGIN failed--compilation aborted` / `Compilation failed in require` line is present. Prefer a conservative rule and pin it with the tests below.
+- `header` is `"Perl error:"`.
+- `message` is the first line with its trailing ` at FILE line N.` location stripped (e.g. `Illegal division by zero`).
+- `frames` come from the innermost location plus every `\t<SUB> called at <FILE> line <N>` line, converted to OUTERMOST-first order to match Python's convention. Skip `eval {...} called at` frames — they are perl's compile-phase scaffolding, not user frames.
+- For `has_begin.pl` the expected result is message `Illegal division by zero`, frames `[(".../has_begin.pl", 11, "main::BEGIN"), (".../has_begin.pl", 10, "")]` (outermost-first: the caller at line 11, then the failing statement at line 10).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/unit/test_error_parsers.py
+from tdb.languages.errors import parse_perl_error
+
+PERL_COMPILE = """Illegal division by zero at /w/has_begin.pl line 10.
+ at /w/has_begin.pl line 10.
+\tmain::BEGIN() called at /w/has_begin.pl line 11
+\teval {...} called at /w/has_begin.pl line 11
+BEGIN failed--compilation aborted at /w/has_begin.pl line 11.
+"""
+
+PERL_RUNTIME = "Illegal division by zero at /tmp/x.pl line 4.\n"
+
+PERL_DIE_IN_SUB = """boom at /tmp/x.pl line 3.
+\tmain::inner() called at /tmp/x.pl line 7
+\tmain::outer() called at /tmp/x.pl line 10
+"""
+
+
+def test_perl_returns_none_for_plain_output():
+    assert parse_perl_error("hello world\n") is None
+
+
+def test_perl_runtime_die_message_and_frame():
+    p = parse_perl_error(PERL_RUNTIME)
+    assert p is not None
+    assert p.header == "Perl error:"
+    assert p.message == "Illegal division by zero"
+    assert [(f.path, f.line) for f in p.frames] == [("/tmp/x.pl", 4)]
+
+
+def test_perl_compile_abort_frames_skip_eval_scaffolding():
+    p = parse_perl_error(PERL_COMPILE)
+    assert p is not None
+    assert p.message == "Illegal division by zero"
+    assert [(f.path, f.line, f.func) for f in p.frames] == [
+        ("/w/has_begin.pl", 11, "main::BEGIN"),
+        ("/w/has_begin.pl", 10, ""),
+    ]
+
+
+def test_perl_nested_call_frames_outermost_first():
+    p = parse_perl_error(PERL_DIE_IN_SUB)
+    assert p is not None
+    assert [(f.line, f.func) for f in p.frames] == [
+        (10, "main::outer"),
+        (7, "main::inner"),
+        (3, ""),
+    ]
+
+
+def test_perl_warning_alone_is_not_fatal():
+    warn = "Use of uninitialized value in division (/) at /w/x.pl line 10.\n"
+    assert parse_perl_error(warn) is None
+
+
+def test_presentation_exposes_parser_for_perl():
+    from tdb.languages import registry
+
+    profile = registry.resolve("perl")
+    assert profile.presentation.parse_error is not None
+    assert profile.presentation.parse_error(PERL_RUNTIME) is not None
+```
+
+Implementer note: `test_perl_warning_alone_is_not_fatal` is the constraint that forces a conservative detector. If your rule cannot separate a lone warning from a lone runtime die (both are a single `... at FILE line N.` line), prefer treating a **lone** trailing-location line as fatal ONLY when it does not begin with a known warning prefix — and if you cannot make that reliable, report the conflict rather than deleting the test: the alternative is to have the Perl adapter mark the stderr region that follows the last resumption, which is Task 4 territory. Resolve it, document what you chose in the report, and keep every other test.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/test_error_parsers.py -q --no-cov`
+Expected: FAIL — `ImportError: cannot import name 'parse_perl_error'`
+
+- [ ] **Step 3: Implement** `parse_perl_error` in `errors.py`; wire it into `perl.py`'s `Presentation(...)`.
+
+- [ ] **Step 4: Verify green**
+
+Run: `uv run pytest tests/unit/test_error_parsers.py tests/unit -q --no-cov`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tdb/languages/errors.py src/tdb/languages/perl.py tests/unit/test_error_parsers.py
+git commit -m "feat: parse perl die output into a ParsedError
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Route the modal through the profile
+
+**Files:**
+- Modify: `src/tdb/app_handlers/dap_events.py` (`_check_stderr_traceback`, ~206-295; `_show_exception_modal`, ~118-150)
+- Modify: `src/tdb/widgets/modals.py` (`_TracebackModal.compose`, ~381)
+- Test: `tests/unit/test_error_modal_routing.py`
+
+**Interfaces consumed:** `ParsedError`, `Presentation.parse_error` (Tasks 1-2).
+
+Requirements:
+- `_check_stderr_traceback` must read `self.app.controller.profile.presentation.parse_error`; return immediately when it is `None` or returns `None`. All the downstream machinery — building `StackFrame`/`Source`, `state.set_stack(frames, synthetic=True)`, caching `panels.last_exception_text` / `last_frames_text` / `last_can_restart`, pushing `_TracebackModal`, and the `_update_ui_state()` navigation — stays as it is today and stays language-neutral.
+- Frame list order: `ParsedError.frames` is outermost-first; today's code reverses parsed frames so the deepest is index 0 (DAP order). Preserve that inversion.
+- `_TracebackModal` must render `ParsedError.header` instead of the hardcoded `"Traceback (most recent call last):"`. Give the modal a `header: str` parameter defaulting to the Python string so the third call site (`on_code_view_show_last_traceback` in `app.py`) keeps working; cache the header alongside the other `panels.last_*` values so the `e` re-summon shows the right one.
+- The Python path's observable behavior must not change at all.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/test_error_modal_routing.py
+"""The stderr error modal is driven by the active language profile."""
+
+import pytest
+
+from tdb.app import TdbApp
+from tdb.persist import TdbConfig
+
+PY_TB = '''Traceback (most recent call last):
+  File "/app/main.py", line 3, in <module>
+    boom()
+ZeroDivisionError: division by zero
+'''
+
+PERL_DIE = "Illegal division by zero at /w/x.pl line 4.\n"
+
+
+async def _pushed_modal(app, stderr_text):
+    pushed = []
+    app.push_screen = lambda screen, callback=None: pushed.append(screen)
+    app._stderr_buffer.clear()
+    app._stderr_buffer.append(stderr_text)
+    app._dap._check_stderr_traceback()
+    return pushed
+
+
+async def test_python_traceback_still_shows_modal():
+    app = TdbApp(program="", config=TdbConfig())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pushed = await _pushed_modal(app, PY_TB)
+        assert pushed, "python traceback should push a modal"
+        assert "ZeroDivisionError" in app.panels.last_exception_text
+
+
+async def test_perl_die_shows_modal_with_frames():
+    from tdb.languages import registry
+
+    app = TdbApp(program="", config=TdbConfig(), profile=registry.resolve("perl"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pushed = await _pushed_modal(app, PERL_DIE)
+        assert pushed, "perl die should push a modal"
+        assert "Illegal division by zero" in app.panels.last_exception_text
+        assert "/w/x.pl" in app.panels.last_frames_text
+        # Code View / stack navigated to the failing frame
+        assert app.controller.state.stack_frames
+        assert app.controller.state.stack_frames[0].line == 4
+
+
+async def test_non_error_stderr_shows_nothing():
+    from tdb.languages import registry
+
+    app = TdbApp(program="", config=TdbConfig(), profile=registry.resolve("perl"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pushed = await _pushed_modal(app, "just a log line\n")
+        assert pushed == []
+```
+
+Implementer note: check how `_check_stderr_traceback` is reached (it is called from `on_terminated`) and whether `state.set_stack(..., synthetic=True)` needs a live session; adapt the test's plumbing (not its assertions) if a mounted app with `program=""` cannot reach it directly. If `app._dap` is not the attribute name for the `DapEventCoordinator`, use the real one.
+
+- [ ] **Step 2: Run to verify failure** — expected: the Perl test fails (no modal pushed) while the Python test passes.
+
+- [ ] **Step 3: Implement** the profile-driven refactor + modal header parameter.
+
+- [ ] **Step 4: Verify green**
+
+Run: `uv run pytest tests/unit/test_error_modal_routing.py tests/unit -q --no-cov`
+Expected: all pass, including every pre-existing traceback/modal test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tdb/app_handlers/dap_events.py src/tdb/widgets/modals.py tests/unit/test_error_modal_routing.py
+git commit -m "feat: drive the error modal from the language profile
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Report the debuggee's real exit code
+
+**Files:**
+- Modify: `src/tdb/adapters/perl/server.py` (`_classify_and_emit_stop`'s `"?"` branch ~315-322; `_forward_output`'s `__eof__` branch ~292-296)
+- Modify: `src/tdb/adapters/perl/session.py` (expose the child's exit status)
+- Test: `tests/integration/test_perl_exit_code.py`
+
+Today both termination routes hardcode `{"exitCode": 0}`, so a program that died is indistinguishable from a clean exit. Add a way to read the owned child's return code (launch mode only; attach has no owned child — keep `0` there) and report it.
+
+Note the child may not have reaped yet when perl5db parks at its "terminated" prompt: perl5db stays alive at a live prompt after the program ends. Wait for the process with a short bounded timeout (~2 s) and fall back to `0` rather than blocking the event loop.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/integration/test_perl_exit_code.py
+"""A perl program that dies must not report exitCode 0."""
+
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, "tests/integration")
+from perl_adapter_harness import AdapterClient
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("perl") is None
+    or subprocess.run(["perl", "-e", "require v5.18"]).returncode != 0,
+    reason="perl >= 5.18 required",
+)
+
+
+async def _run_to_exit(tmp_path, source):
+    prog = tmp_path / "p.pl"
+    prog.write_text(source)
+    c = AdapterClient()
+    await c.start()
+    await c.request("initialize", {})
+    c.send("launch", {"program": str(prog), "cwd": str(tmp_path)})
+    await c.wait_event("initialized")
+    await c.request("configurationDone", {})
+    await c.wait_event("stopped")
+    await c.request("continue", {"threadId": 1})
+    ev = await c.wait_event("exited", timeout=30)
+    await c.stop()
+    return ev["body"]["exitCode"]
+
+
+async def test_clean_exit_reports_zero(tmp_path):
+    assert await _run_to_exit(tmp_path, 'print "ok\\n";\n') == 0
+
+
+async def test_die_reports_nonzero(tmp_path):
+    code = await _run_to_exit(tmp_path, 'my $x = 0;\nmy $y = 1 / $x;\n')
+    assert code != 0
+```
+
+- [ ] **Step 2: Run to verify failure** — expected: `test_die_reports_nonzero` fails with `0 != 0`.
+- [ ] **Step 3: Implement.**
+- [ ] **Step 4: Verify green** — `uv run pytest tests/integration/test_perl_exit_code.py tests/integration -k perl -q --no-cov`
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tdb/adapters/perl/server.py src/tdb/adapters/perl/session.py tests/integration/test_perl_exit_code.py
+git commit -m "fix: report the perl debuggee's real exit code
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Compile-phase stopping (BEGIN blocks)
+
+This is the largest task. Read Background §1-4 and §8 before starting.
+
+**Files:**
+- Create: `src/tdb/adapters/perl/Devel/TdbCompile.pm`
+- Modify: `src/tdb/adapters/perl/helpers.pl` (add `phase()`)
+- Modify: `src/tdb/adapters/perl/session.py` (`launch`)
+- Modify: `src/tdb/adapters/perl/server.py` (defer breakpoints during compile phase)
+- Modify: `pyproject.toml` if package data globs don't already ship `Devel/*.pm` (check — `Devel/TdbRemote.pm` already ships, so this probably needs nothing)
+- Test: `tests/integration/test_perl_begin_blocks.py`
+
+**Reference implementation of the shim** (verified working — use it, adapting only the self-trap fix):
+
+```perl
+package Devel::TdbCompile;
+BEGIN {
+    my $target = $ENV{TDB_COMPILE_FILE} or return;
+    my $orig = \&DB::DB;
+    no warnings 'redefine';
+    *DB::DB = sub {
+        if ( ${^GLOBAL_PHASE} ne 'START' ) {
+            *DB::DB = $orig;
+            goto &$orig;
+        }
+        my ( undef, $file ) = caller;
+        return unless defined $file && $file eq $target;
+        goto &$orig;
+    };
+    $DB::single = 1;
+}
+1;
+```
+
+**Requirements:**
+
+1. `session.py::launch` inserts `-I<dir-of-adapters/perl>` and `-MDevel::TdbCompile` into the perl argv before the program, and sets `TDB_COMPILE_FILE` in the child env to the program path exactly as perl will report it in `caller` (the same string perl5db uses for `main::(<file>:<line>)`). Verify the match empirically — a mismatch silently disables the whole feature.
+2. Attach mode (`Devel::TdbRemote`) is unchanged: the program is already running when tdb attaches, so there is no compile phase to catch.
+3. **No stop may ever surface inside `TdbCompile.pm`.** The verified prototype leaked exactly one stop at its own `goto &$orig;` line during the START→RUN transition. Fix it — either by keeping the shim installed and making the RUN branch a pure pass-through, or by having the adapter auto-step past a stop whose file is `TdbCompile.pm` (the same pattern `_on_attach` already uses to step out of `TdbRemote`). Add an assertion for this to the tests.
+4. Add `Devel::TdbHelper::phase()` to `helpers.pl`, emitting `{"phase": "${^GLOBAL_PHASE}"}`. Keep it inside an `eval` and degrade to a JSON error like every other helper. Do NOT bump `$PROTOCOL`.
+5. **Breakpoint deferral (critical — see Background §8).** During the compile phase the user's file is only partially compiled, so `breakable()` reports a partial line table and `b file:line` answers `not breakable` for later lines. `_on_setBreakpoints` must therefore, when `phase()` reports `START`: store the request as pending, respond with the requested breakpoints marked `verified: false`, and NOT call `breakable()` or `b` at all (calling `breakable()` on a partially-compiled file risks the line-table poisoning documented in `helpers.pl`'s own comments). When the adapter next observes a stop with phase `RUN`, flush every pending request through the existing `_on_setBreakpoints` logic and emit a DAP `breakpoint` **changed** event per breakpoint so the UI updates its verified state.
+6. Statement-stepping and END-block behavior must not regress (Background §5).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/integration/test_perl_begin_blocks.py
+"""BEGIN blocks are steppable: tdb stops during perl's compile phase."""
+
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, "tests/integration")
+from perl_adapter_harness import AdapterClient
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("perl") is None
+    or subprocess.run(["perl", "-e", "require v5.18"]).returncode != 0,
+    reason="perl >= 5.18 required",
+)
+
+WITH_BEGIN = """use strict;
+use warnings;
+
+BEGIN {
+    my $x = 10;
+    my $y = $x * 2;
+    print STDERR "begin $x $y\\n";
+}
+
+my $b = 20;
+print STDERR "main $b\\n";
+
+END {
+    my $z = 99;
+    print STDERR "end $z\\n";
+}
+"""
+
+NO_PRAGMAS = 'my $a = 1;\nmy $b = 2;\nprint STDERR "x\\n";\n'
+
+
+async def _launch(tmp_path, source, name="p.pl"):
+    prog = tmp_path / name
+    prog.write_text(source)
+    c = AdapterClient()
+    await c.start()
+    await c.request("initialize", {})
+    c.send("launch", {"program": str(prog), "cwd": str(tmp_path)})
+    await c.wait_event("initialized")
+    await c.request("configurationDone", {})
+    await c.wait_event("stopped")
+    return c, str(prog)
+
+
+async def _where(c):
+    st = await c.request("stackTrace", {"threadId": 1})
+    f = st["body"]["stackFrames"][0]
+    return f["source"]["path"], f["line"], f["name"]
+
+
+async def test_first_stop_is_compile_phase_statement(tmp_path):
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        path, line, _ = await _where(c)
+        assert path == prog
+        assert line == 1  # `use strict;` -- a compile-time statement
+    finally:
+        await c.stop()
+
+
+async def test_step_reaches_inside_the_begin_block(tmp_path):
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        seen = []
+        for _ in range(12):
+            path, line, name = await _where(c)
+            seen.append((line, name))
+            if line == 5:  # `my $x = 10;` inside BEGIN
+                break
+            await c.request("stepIn", {"threadId": 1})
+            await c.wait_event("stopped", timeout=20)
+        assert any(line == 5 for line, _ in seen), f"never entered BEGIN: {seen}"
+        assert all(
+            "TdbCompile" not in str(p) for p in [prog]
+        )  # sanity; real check below
+    finally:
+        await c.stop()
+
+
+async def test_no_stop_is_reported_inside_tdbcompile_pm(tmp_path):
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        for _ in range(20):
+            path, _, _ = await _where(c)
+            assert "TdbCompile.pm" not in path, "leaked a stop inside tdb's own shim"
+            await c.request("stepIn", {"threadId": 1})
+            try:
+                await c.wait_event("stopped", timeout=15)
+            except AssertionError:
+                break
+    finally:
+        await c.stop()
+
+
+async def test_program_without_compile_time_statements_unchanged(tmp_path):
+    c, prog = await _launch(tmp_path, NO_PRAGMAS)
+    try:
+        path, line, _ = await _where(c)
+        assert (path, line) == (prog, 1)
+    finally:
+        await c.stop()
+
+
+async def test_breakpoints_set_during_compile_phase_still_fire(tmp_path):
+    """Regression for the partial-line-table hazard: a breakpoint requested
+    at the first (compile-phase) stop must fire once the program runs."""
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        await c.request(
+            "setBreakpoints",
+            {"source": {"path": prog}, "breakpoints": [{"line": 11}]},
+        )
+        await c.request("continue", {"threadId": 1})
+        await c.wait_event("stopped", timeout=30)
+        path, line, _ = await _where(c)
+        assert (path, line) == (prog, 11)
+    finally:
+        await c.stop()
+
+
+async def test_end_block_still_steppable(tmp_path):
+    """Background 5: END blocks already worked; must not regress."""
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        await c.request(
+            "setBreakpoints",
+            {"source": {"path": prog}, "breakpoints": [{"line": 11}]},
+        )
+        await c.request("continue", {"threadId": 1})
+        await c.wait_event("stopped", timeout=30)
+        seen = []
+        for _ in range(8):
+            await c.request("stepIn", {"threadId": 1})
+            try:
+                await c.wait_event("stopped", timeout=15)
+            except AssertionError:
+                break
+            _, line, name = await _where(c)
+            seen.append((line, name))
+        assert any("END" in str(name) for _, name in seen), f"END not reached: {seen}"
+    finally:
+        await c.stop()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/integration/test_perl_begin_blocks.py -q --no-cov`
+Expected: the compile-phase tests fail (first stop is the first *runtime* statement, line 10). `test_end_block_still_steppable` and `test_program_without_compile_time_statements_unchanged` may already pass — that is correct and expected.
+
+- [ ] **Step 3: Implement** the shim, the launch wiring, `phase()`, and breakpoint deferral.
+
+- [ ] **Step 4: Verify green, and re-check the whole Perl suite**
+
+Run: `uv run pytest tests/integration/test_perl_begin_blocks.py -q --no-cov`, then `uv run pytest tests/unit -q --no-cov` and `uv run pytest tests/integration -q --no-cov`.
+Several pre-existing Perl tests assert the entry-stop location; where the new default legitimately changes it, update those expectations and say so in your report — but if a pre-existing test fails in a way that indicates a real behavior regression (breakpoints not firing, inspection broken, attach changed), fix the product, not the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tdb/adapters/perl/Devel/TdbCompile.pm src/tdb/adapters/perl/helpers.pl src/tdb/adapters/perl/session.py src/tdb/adapters/perl/server.py tests/integration/test_perl_begin_blocks.py
+git commit -m "feat: stop during perl's compile phase so BEGIN blocks are steppable
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Documentation + full-suite gate
+
+**Files:**
+- Modify: `README.md`
+- Modify: `SKILL.md` if it documents Perl behavior (check)
+- Test: full suites
+
+- [ ] **Step 1: Document** in the Perl section of README.md:
+  - Fatal Perl errors now open the error modal with the message, the call stack, and Code View navigation to the failing line — same as Python.
+  - tdb stops during perl's **compile phase**, so the first stop is the first compile-time statement of your program (typically `use strict;` on line 1-2) rather than the first runtime statement, and `BEGIN` blocks can be stepped into.
+  - `END` blocks are entered with **step-in** (`s`); `next`/`continue` run past them to termination.
+  - Limitation: breakpoints requested while the program is still compiling are reported unverified and applied once compilation finishes, because perl's line table is incomplete during the compile phase. A breakpoint *inside* a `BEGIN` block therefore may not fire on the first run — step into the block from the initial stop instead.
+  - Limitation: the compile-phase shim adds a per-statement filter during compilation, so programs with very large `use` graphs start more slowly under tdb.
+
+- [ ] **Step 2: Full-suite gate**
+
+Run: `uv run pytest tests/unit -q --no-cov` and `uv run pytest tests/integration -q --no-cov`. Both must be green; report the counts.
+
+- [ ] **Step 3: Manual end-to-end verification against the user's own file**
+
+Run the adapter against `work/has_begin.pl` (a scripted `AdapterClient` session is fine — do not try to drive the TUI) and confirm in your report, with pasted output: (a) a stop occurs inside the BEGIN block at line 7, and (b) the stderr the adapter forwards, when fed to `parse_perl_error`, yields message `Illegal division by zero` with a frame at `has_begin.pl:10`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: perl error modal and compile-phase BEGIN debugging
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
   [project]
   name = "textual-debugger"
   dynamic = ["version"]
-  description = "A TUI Python debugger based on textual and debugpy"
+  description = "A TUI debugger for Python, Perl, and other languages.  Based on textual."
   readme = "README.md"
   requires-python = ">=3.10"
   license = {file = "LICENSE"}
@@ -17,6 +17,9 @@
       "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
       "Programming Language :: Python :: 3.12",
+      "Programming Language :: Python :: 3.13",
+      "Programming Language :: Python :: 3.14",
+      "Programming Language :: Python :: 3.15",
       "Topic :: Software Development :: Debuggers",
   ]
   dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@
   where = ["src"]
 
   [tool.setuptools.package-data]
-  tdb = ["README.md", "adapters/perl/helpers.pl", "adapters/perl/Devel/TdbRemote.pm"]
+  tdb = ["README.md", "adapters/perl/helpers.pl", "adapters/perl/Devel/TdbRemote.pm", "adapters/perl/Devel/TdbCompile.pm"]
 
   [tool.pytest.ini_options]
   testpaths = ["tests"]

--- a/src/tdb/__init__.py
+++ b/src/tdb/__init__.py
@@ -1,6 +1,6 @@
 from tdb.breakpoint_hook import breakpoint
 from tdb.post_mortem import exception_hook
 
-__version__ = "0.2.2"  # trailing digit odd == dev version
+__version__ = "0.2.3"  # trailing digit odd == dev version
 
 __all__ = ["breakpoint", "exception_hook"]

--- a/src/tdb/adapters/perl/Devel/TdbCompile.pm
+++ b/src/tdb/adapters/perl/Devel/TdbCompile.pm
@@ -1,0 +1,68 @@
+# Devel::TdbCompile -- arms perl5db to trap during the COMPILE phase so
+# BEGIN blocks (and any other compile-time statement of the debuggee's
+# own file) become steppable, instead of perl5db's default of only
+# ever stopping once runtime execution begins (see perldebug,
+# "Debugging Compile-Time Statements", and the plan's Background 1-3).
+#
+#   perl -d -I<dir of this file> -MDevel::TdbCompile prog.pl
+#
+# with $ENV{TDB_COMPILE_FILE} set (by session.py::launch) to the exact
+# string perl will report as the program's file in `caller` -- i.e.
+# argv's program path, verbatim (perl does not resolve/canonicalize
+# it; confirmed empirically against 5.40.1).
+#
+# Only launch mode loads this module. Attach mode (Devel::TdbRemote)
+# is unaffected: the debuggee is already running by the time tdb
+# attaches, so there is no compile phase left to catch.
+package Devel::TdbCompile;
+
+BEGIN {
+    my $target = $ENV{TDB_COMPILE_FILE};
+    return unless defined $target && length $target;
+
+    # perl5db.pl must already be loaded (`-d` guarantees this runs
+    # before us) so &DB::DB exists to wrap.
+    my $orig = \&DB::DB;
+    no warnings 'redefine';
+
+    # MUST self-uninstall (`*DB::DB = $orig`) the moment
+    # ${^GLOBAL_PHASE} leaves 'START', restoring the original DB::DB
+    # before the tail-call `goto`. This is not a micro-optimisation --
+    # it is required for correctness. An earlier version left the
+    # wrapper installed for the rest of the process's life and made
+    # the RUN-phase branch a bare `goto &$orig` pass-through; verified
+    # empirically, that combination reliably makes perl die with
+    # "Out of memory in perl:util:safesysmalloc" once run-phase
+    # execution proceeds. Self-uninstalling avoids that entirely: only
+    # the compile phase (a handful of statements) ever pays the cost
+    # of this wrapper at all.
+    #
+    # Self-uninstalling does leak exactly one stop at this
+    # reassignment/goto line, INSIDE this file, during the START->RUN
+    # transition -- a shim implementation detail that would otherwise
+    # surface in the user-visible debugging session. That is handled
+    # on the Perl side by `_user_frames` in helpers.pl, which already
+    # skips frames whose package is Devel::TdbCompile, and belt-and-
+    # suspenders on the adapter side by auto-stepping past any stop
+    # that still lands in TdbCompile.pm (see server.py).
+    *DB::DB = sub {
+        if ( ${^GLOBAL_PHASE} ne 'START' ) {
+            *DB::DB = $orig;
+            goto &$orig;
+        }
+        # Still compiling: only trap statements belonging to the
+        # debuggee's own file (BEGIN blocks, `use` pragmas, etc.) --
+        # naively arming $DB::single here would also drag the user
+        # through strict.pm/warnings.pm/every `use`d module's own
+        # compile-time internals.
+        my ( undef, $file ) = caller;
+        return unless defined $file && $file eq $target;
+        goto &$orig;
+    };
+
+    # Arm single-stepping before perl even starts compiling the
+    # target file, so the very first compile-time statement traps.
+    $DB::single = 1;
+}
+
+1;

--- a/src/tdb/adapters/perl/helpers.pl
+++ b/src/tdb/adapters/perl/helpers.pl
@@ -372,6 +372,30 @@ sub vars {
     return;
 }
 
+sub cond_result {
+    my ( $ok, $err ) = @_;
+    eval {
+        if ($err) {
+            my $msg = "$err";
+            $msg =~ s/\s+\z//;
+            # fail-CLOSED, matching perl5db's own conditional-breakpoint
+            # semantics (_DB__determine_if_we_should_break's
+            # `$DB::signal |= 1 if do {$stop}` -- a condition that dies
+            # aborts the `if` before the assignment runs, so a real
+            # runtime conditional breakpoint with an erroring condition
+            # never fires either; confirmed empirically). server.py's
+            # _eval_condition treats the presence of "error" as false
+            # regardless of "ok", so this exact value doesn't matter, but
+            # keep it false for clarity if ever inspected directly.
+            _emit( { ok => JSON::PP::false, error => $msg } );
+            return 1;
+        }
+        _emit( { ok => ( $ok ? JSON::PP::true : JSON::PP::false ) } );
+        1;
+    } or _emit_error($@);
+    return;
+}
+
 sub emit_eval {
     my ( $results, $err ) = @_;
     eval {

--- a/src/tdb/adapters/perl/helpers.pl
+++ b/src/tdb/adapters/perl/helpers.pl
@@ -79,7 +79,7 @@ sub _user_frames {
     while ( my @c = caller($i) ) {
         my ( $pkg, $file, $line ) = @c[ 0, 1, 2 ];
         $i++;
-        next if $pkg =~ /\A(?:DB\b|Devel::TdbHelper|Devel::TdbRemote)/;
+        next if $pkg =~ /\A(?:DB\b|Devel::TdbHelper|Devel::TdbRemote|Devel::TdbCompile)/;
         next if $file =~ /\(eval \d+\)/;
         my $sub = ( caller($i) )[3];    # sub that contains this frame
         push @frames, [ $file, $line, $sub ];
@@ -101,6 +101,23 @@ sub location {
                 sub     => $top->[2],
             }
         );
+        1;
+    } or _emit_error($@);
+    return;
+}
+
+
+# ${^GLOBAL_PHASE} is 'START' for perl's ENTIRE initial compile of the
+# top-level program (every `use`/BEGIN block, in every file) and flips
+# to 'RUN' exactly once, right as mainline execution begins -- by
+# which point the whole top-level file has finished compiling, even
+# the parts execution hasn't reached yet. The Perl adapter's
+# server.py uses this to decide when it's finally safe to call
+# breakable()/b for a file whose compile-phase stop it caught (see
+# breakable()'s own comment on the partial-line-table hazard).
+sub phase {
+    eval {
+        _emit( { phase => "${^GLOBAL_PHASE}" } );
         1;
     } or _emit_error($@);
     return;

--- a/src/tdb/adapters/perl/server.py
+++ b/src/tdb/adapters/perl/server.py
@@ -348,18 +348,40 @@ class PerlDapServer:
                 # code becomes available.
                 self.current_stop = None
                 session = self.session
-                if session.pid is not None:
-                    # Owned child (launch mode). `q` closes the debug
-                    # socket, which the read loop will also observe as EOF
-                    # and route through _forward_output's "__eof__" branch
-                    # -- set _eof_terminated first (before any await lets
-                    # that run) so it's a no-op there instead of a second
+                # Finding 1 (task-4 review): `loc is None` means location()
+                # RAISED (timeout, malformed/missing JSON, mid-flight EOF)
+                # -- an inconclusive/error state, not proof the debuggee
+                # ended. It can just as easily mean the debuggee is
+                # legitimately stopped at a real breakpoint/pause, so it
+                # must NOT trigger `q` (that would kill a live session).
+                # Only a CONFIRMED "?" location does. `loc is None` keeps
+                # reporting termination (unchanged pre-existing behavior)
+                # with exit code 0 -- we genuinely don't know it.
+                #
+                # NOTE for a later task: any future compile-phase stop must
+                # report a real file from location(), never "?" -- otherwise
+                # it would trip this same "ended" branch.
+                if loc is not None and session.pid is not None:
+                    # Owned child (launch mode) AND a confirmed "?" location.
+                    # `q` closes the debug socket, which the read loop will
+                    # also observe as EOF and route through
+                    # _forward_output's "__eof__" branch -- set
+                    # _eof_terminated first (before any await lets that
+                    # run) so it's a no-op there instead of a second
                     # terminated/exited pair.
                     self._eof_terminated = True
                     try:
                         await session.command("q")
                     except PerlProtocolError:
                         pass  # expected: the connection closes, no prompt follows
+                    if not session.eof:
+                        # Finding 2 (task-4 review): `q` did NOT actually
+                        # close the connection (timed out waiting for a
+                        # prompt, or perl5db replied without dying) -- no
+                        # __eof__ is coming to consume the flag. Clear it
+                        # now so it can't dangle and silently swallow the
+                        # NEXT, genuinely unrelated __eof__ termination.
+                        self._eof_terminated = False
                     exit_code = await session.wait_exit_code()
                 else:
                     # Attach mode: no owned child, and forcing `q` would

--- a/src/tdb/adapters/perl/server.py
+++ b/src/tdb/adapters/perl/server.py
@@ -57,6 +57,11 @@ class PerlDapServer:
         # stack(), so _classify_and_emit_stop can compare loc["file"]
         # against it directly with no further translation.
         self.breakpoint_lines: dict[str, set[int]] = {}
+        # setBreakpoints requests deferred because perl was still
+        # compiling `remote_path` when they arrived (see
+        # _on_setBreakpoints and Background 8 in the plan): remote_path
+        # -> (local_path, wanted). Flushed once phase() reports 'RUN'.
+        self._pending_breakpoints: dict[str, tuple[str, list[dict]]] = {}
         self.refs = RefRegistry()
         self.handlers: dict[str, Callable[[Request], Awaitable[None]]] = {}
         for name in dir(self):
@@ -281,21 +286,120 @@ class PerlDapServer:
             if self._stop_on_entry:
                 await self._emit_stopped("entry")
             else:
+                # Mirrors _on_continue's guard: a bare "c" here races past
+                # any breakpoints deferred (Background 8) while still
+                # stopped at the entry prompt, the same way an explicit
+                # continue request would.
+                if self._pending_breakpoints:
+                    await self._settle_to_run_phase()
                 self.session.resume("c")
 
     async def _emit_stopped(self, reason: str) -> None:
         self.refs.reset()
-        try:
-            self.current_stop = await self.session.helper(
-                "Devel::TdbHelper::location()"
-            )
-        except PerlProtocolError as e:
-            log.error("location() failed after stop: %s", e)
-            self.current_stop = None
+        self.current_stop = await self._location_after_settling()
+        if self._pending_breakpoints:
+            await self._flush_pending_if_run()
         self.send_event(
             "stopped",
             {"reason": reason, "threadId": 1, "allThreadsStopped": True},
         )
+
+    async def _location_after_settling(self) -> dict | None:
+        """`Devel::TdbHelper::location()`, auto-stepping past any stop
+        that lands inside our own compile-phase shim.
+
+        Requirement: no stop may ever surface inside TdbCompile.pm --
+        it wraps DB::DB for the debuggee's whole lifetime (see that
+        module's own header comment on why it stays installed), and as
+        a defense-in-depth belt-and-suspenders on top of that module's
+        own fix, if a stray trap ever DOES land there, auto-step past
+        it (the same auto-step-out-to-caller pattern _on_attach already
+        uses for Devel::TdbRemote) rather than surfacing it as a user
+        stop. Bounded so a persistent leak can't hang tdb -- it would
+        instead fall through to the pre-existing "location() gave us
+        nothing usable" handling.
+        """
+        loc = None
+        for _ in range(5):
+            try:
+                loc = await self.session.helper("Devel::TdbHelper::location()")
+            except PerlProtocolError as e:
+                log.error("location() failed after stop: %s", e)
+                return None
+            file = loc.get("file") or ""
+            if "TdbCompile.pm" not in file:
+                return loc
+            log.warning("stray stop inside TdbCompile.pm; stepping past it")
+            try:
+                await self.session.command("n")
+            except PerlProtocolError as e:
+                log.error("step-past-shim failed: %s", e)
+                return None
+        return loc
+
+    async def _current_phase(self) -> str | None:
+        """`${^GLOBAL_PHASE}` at the debuggee's current stop, or None if
+        it can't be determined (e.g. an older debuggee-side helpers.pl
+        without phase() -- degrade to "don't defer", matching
+        pre-compile-phase behavior)."""
+        if self.session is None:
+            return None
+        try:
+            return (await self.session.helper("Devel::TdbHelper::phase()"))["phase"]
+        except PerlProtocolError:
+            return None
+
+    async def _settle_to_run_phase(self) -> None:
+        """Advance a debuggee that's still in perl's compile phase up to
+        the RUN-phase transition before letting a real `c` (continue)
+        run, then flush breakpoints deferred while compiling (Background
+        8). A bare `c` clears perl5db's single-step flag; with no real
+        breakpoint armed yet in the target file (that's the whole point
+        of the deferral -- calling `b`/breakable() on a partially
+        compiled file risks poisoning its line table, see helpers.pl's
+        breakable()), it would run straight to program completion,
+        racing past wherever those breakpoints should have fired.
+        Single-stepping (`n`) instead keeps landing on the shim's own
+        traps (compile-time statements in the target file, then the
+        RUN-phase transition itself) without that risk. ${^GLOBAL_PHASE}
+        flips to RUN only once the WHOLE top-level file has finished
+        compiling -- even the parts execution hasn't reached yet -- so
+        by the time this loop exits it's safe to apply the deferred
+        breakpoints for real. Bounded so a pathological compile phase
+        can't hang tdb.
+        """
+        for _ in range(1000):
+            phase = await self._current_phase()
+            if phase != "START":
+                break
+            try:
+                await self.session.command("n")
+            except PerlProtocolError as e:
+                log.error("compile-phase settle step failed: %s", e)
+                break
+        await self._flush_pending_if_run()
+
+    async def _flush_pending_if_run(self) -> None:
+        if not self._pending_breakpoints or self.session is None:
+            return
+        phase = await self._current_phase()
+        if phase == "START":
+            return
+        pending, self._pending_breakpoints = self._pending_breakpoints, {}
+        for remote_path, (local_path, wanted) in pending.items():
+            results = await self._apply_breakpoints(remote_path, wanted)
+            for r in results:
+                self.send_event(
+                    "breakpoint",
+                    {
+                        "reason": "changed",
+                        "breakpoint": {
+                            "verified": r["verified"],
+                            "line": r["line"],
+                            "source": {"path": local_path},
+                        },
+                    },
+                )
 
     def _forward_output(self, text: str, category: str) -> None:
         if category == "__eof__":
@@ -333,10 +437,7 @@ class PerlDapServer:
         try:
             if self.session is None:
                 return
-            try:
-                loc = await self.session.helper("Devel::TdbHelper::location()")
-            except PerlProtocolError:
-                loc = None
+            loc = await self._location_after_settling()
             if loc is None or loc.get("file") == "?":
                 # perl5db's "ended" state: the debuggee ran to completion and
                 # perl5db parked at a live prompt without closing the socket
@@ -392,6 +493,8 @@ class PerlDapServer:
                 self.send_event("exited", {"exitCode": exit_code})
                 return
             self.current_stop = loc
+            if self._pending_breakpoints:
+                await self._flush_pending_if_run()
             had_pause_pending = self._pause_pending
             self._pause_pending = False
             # loc["file"] comes straight from perl5db's location() -- it's
@@ -441,6 +544,16 @@ class PerlDapServer:
         self.session.resume(cmd)
 
     async def _on_continue(self, request: Request) -> None:
+        # Only `continue` needs the settle-past-compile-phase guard
+        # (_settle_to_run_phase): it's the one resume command with no
+        # bound on how far it runs, so it's the one that can race past
+        # breakpoints deferred while perl was still compiling (Background
+        # 8). next/stepIn/stepOut always land on the very next statement
+        # -- they can't skip over the deferred file's own later lines --
+        # so a stop reaching RUN phase there is caught by
+        # _classify_and_emit_stop's reactive flush instead.
+        if self._pending_breakpoints and self._not_ready() is None:
+            await self._settle_to_run_phase()
         await self._resume(request, "c")
 
     async def _on_next(self, request: Request) -> None:
@@ -497,6 +610,38 @@ class PerlDapServer:
         path = request.arguments.get("source", {}).get("path", "")
         remote_path = self._to_remote(path)
         wanted = request.arguments.get("breakpoints", [])
+        # Background 8 / requirement 5: while perl is still compiling
+        # `remote_path` (phase 'START'), its line table is only
+        # partially populated -- breakable() would report a partial
+        # table and `b file:line` answers "not breakable" for lines
+        # after wherever compilation has reached so far, AND calling
+        # breakable() on a not-yet-fully-compiled file risks the
+        # line-table-poisoning hazard documented on that helper (merely
+        # dereferencing its perl line-table array autovivifies it).
+        # Defer instead of ever calling either: store the request,
+        # answer unverified now, and apply for real once
+        # phase() reports 'RUN' (the whole top-level file has finished
+        # compiling by then, even lines execution hasn't reached yet --
+        # see _settle_to_run_phase). Attach mode never sees phase
+        # 'START' here (the debuggee is already running by the time tdb
+        # attaches), so this is a no-op there.
+        if await self._current_phase() == "START":
+            self._pending_breakpoints[remote_path] = (path, wanted)
+            results = [{"verified": False, "line": bp["line"]} for bp in wanted]
+            self.send_response(request, {"breakpoints": results})
+            return
+        # A later, non-deferred request for this same file supersedes
+        # any earlier deferred one still waiting to be flushed.
+        self._pending_breakpoints.pop(remote_path, None)
+        results = await self._apply_breakpoints(remote_path, wanted)
+        self.send_response(request, {"breakpoints": results})
+
+    async def _apply_breakpoints(
+        self, remote_path: str, wanted: list[dict]
+    ) -> list[dict]:
+        """The real `b`/`B` exchange with perl5db -- safe only once
+        `remote_path` is known to be fully compiled (see
+        _on_setBreakpoints and _flush_pending_if_run, its two callers)."""
         # breakpoint_lines is keyed by REMOTE path (see __init__ comment).
         old_lines = self.breakpoint_lines.get(remote_path, set())
         if old_lines:
@@ -551,7 +696,7 @@ class PerlDapServer:
                 results.append({"verified": True, "line": target})
                 actual_lines.add(target)
         self.breakpoint_lines[remote_path] = actual_lines
-        self.send_response(request, {"breakpoints": results})
+        return results
 
     @staticmethod
     def _perl_str(s: str) -> str:

--- a/src/tdb/adapters/perl/server.py
+++ b/src/tdb/adapters/perl/server.py
@@ -36,6 +36,14 @@ class PerlDapServer:
         self._done = asyncio.Event()
         self.session: PerlSession | None = None
         self._classify_task: asyncio.Future | None = None
+        # Strong ref for the same reason as _classify_task: asyncio only
+        # holds a weak reference to a bare ensure_future() task.
+        self._eof_task: asyncio.Future | None = None
+        # Set just before _classify_and_emit_stop's "?" branch sends `q` to
+        # force a real child exit -- tells _forward_output's "__eof__"
+        # branch that the resulting socket close is expected, not a fresh
+        # unsolicited termination (see both call sites for detail).
+        self._eof_terminated = False
         self.current_stop: dict | None = None
         self._start_request: Request | None = None
         self._stop_on_entry = True
@@ -291,10 +299,27 @@ class PerlDapServer:
 
     def _forward_output(self, text: str, category: str) -> None:
         if category == "__eof__":
-            self.send_event("terminated")
-            self.send_event("exited", {"exitCode": 0})
+            if self._eof_terminated:
+                # _classify_and_emit_stop's "?" branch already force-quit
+                # perl5db (via `q`) and emitted terminated/exited itself --
+                # THIS eof is that quit closing the socket, not a fresh
+                # unsolicited termination. Emitting again would double-fire
+                # both events.
+                self._eof_terminated = False
+                return
+            # Capture the session reference now: this is an unsolicited
+            # socket close (e.g. the debuggee hard-crashed), so nothing
+            # guarantees `self.session` is still set by the time the
+            # spawned task below actually runs.
+            session = self.session
+            self._eof_task = asyncio.ensure_future(self._emit_termination(session))
             return
         self.send_event("output", {"category": category, "output": text})
+
+    async def _emit_termination(self, session: PerlSession | None) -> None:
+        exit_code = await session.wait_exit_code() if session is not None else 0
+        self.send_event("terminated")
+        self.send_event("exited", {"exitCode": exit_code})
 
     def _on_unsolicited_stop(self) -> None:
         self._classifying = True
@@ -315,10 +340,34 @@ class PerlDapServer:
             if loc is None or loc.get("file") == "?":
                 # perl5db's "ended" state: the debuggee ran to completion and
                 # perl5db parked at a live prompt without closing the socket
-                # (no user frames left, so location() can't report one).
+                # (no user frames left, so location() can't report one). The
+                # underlying child process is genuinely still ALIVE here,
+                # blocked at that prompt (confirmed by probing real
+                # perl5db: `o inhibit_exit` defaults to on) -- it needs an
+                # explicit `q` before it actually exits and a real return
+                # code becomes available.
                 self.current_stop = None
+                session = self.session
+                if session.pid is not None:
+                    # Owned child (launch mode). `q` closes the debug
+                    # socket, which the read loop will also observe as EOF
+                    # and route through _forward_output's "__eof__" branch
+                    # -- set _eof_terminated first (before any await lets
+                    # that run) so it's a no-op there instead of a second
+                    # terminated/exited pair.
+                    self._eof_terminated = True
+                    try:
+                        await session.command("q")
+                    except PerlProtocolError:
+                        pass  # expected: the connection closes, no prompt follows
+                    exit_code = await session.wait_exit_code()
+                else:
+                    # Attach mode: no owned child, and forcing `q` would
+                    # kill the user's live remote process out from under
+                    # them -- never do that here.
+                    exit_code = 0
                 self.send_event("terminated")
-                self.send_event("exited", {"exitCode": 0})
+                self.send_event("exited", {"exitCode": exit_code})
                 return
             self.current_stop = loc
             had_pause_pending = self._pause_pending

--- a/src/tdb/adapters/perl/server.py
+++ b/src/tdb/adapters/perl/server.py
@@ -292,7 +292,10 @@ class PerlDapServer:
                 # stopped at the entry prompt, the same way an explicit
                 # continue request would.
                 if self._pending_breakpoints:
-                    await self._settle_to_run_phase()
+                    hit = await self._settle_to_run_phase()
+                    if hit is not None:
+                        await self._report_pending_hit(hit)
+                        return
                 self.session.resume("c")
 
     async def _emit_stopped(self, reason: str) -> None:
@@ -355,7 +358,7 @@ class PerlDapServer:
         except PerlProtocolError:
             return None
 
-    async def _settle_to_run_phase(self) -> None:
+    async def _settle_to_run_phase(self) -> dict | None:
         """Advance a debuggee that's still in perl's compile phase up to
         the RUN-phase transition before letting a real `c` (continue)
         run, then flush breakpoints deferred while compiling (Background
@@ -373,6 +376,20 @@ class PerlDapServer:
         by the time this loop exits it's safe to apply the deferred
         breakpoints for real. Bounded so a pathological compile phase
         can't hang tdb.
+
+        A pending breakpoint that lands on a compile-time statement (a
+        line inside a BEGIN block, for instance) will never be revisited
+        once RUN phase applies it for real -- that BEGIN block has
+        already finished executing by then. So this loop also checks
+        each new position it steps to against the pending breakpoints
+        for that file and stops early on a match, returning a dict
+        describing the hit (None if it settles into RUN phase without
+        one). Order matters: each iteration steps FIRST and only THEN
+        checks the new location -- on re-entry after a hit the debuggee
+        is still sitting on the line that fired, so checking before
+        stepping would re-fire the same line forever. The position the
+        loop starts from (whatever line the caller was already stopped
+        at) is therefore never itself tested.
         """
         for _ in range(1000):
             phase = await self._current_phase()
@@ -383,7 +400,101 @@ class PerlDapServer:
             except PerlProtocolError as e:
                 log.error("compile-phase settle step failed: %s", e)
                 break
+            hit = await self._check_compile_phase_hit()
+            if hit is not None:
+                return hit
         await self._flush_pending_if_run()
+        return None
+
+    async def _check_compile_phase_hit(self) -> dict | None:
+        """After a compile-phase settle step, check whether the debuggee's
+        new location exactly matches a pending breakpoint's line in the
+        same file. EXACT line equality only -- no snap-forward ("first
+        statement at or after the requested line"): a compile-time
+        statement appearing LATER in the file (e.g. a BEGIN block near
+        the bottom) must never falsely fire a breakpoint meant for an
+        earlier runtime line. `hitCondition` is not supported here (only
+        `condition`, evaluated fail-closed on error -- see
+        _eval_condition); a plain miss (wrong line, or a condition that
+        isn't true) returns None so the settle loop keeps stepping.
+        """
+        loc = await self._location_after_settling()
+        if loc is None:
+            return None
+        remote_path = loc.get("file")
+        entry = self._pending_breakpoints.get(remote_path)
+        if entry is None:
+            return None
+        local_path, wanted = entry
+        line = loc.get("line")
+        for bp in wanted:
+            if bp.get("line") != line:
+                continue
+            cond = bp.get("condition")
+            if cond and not await self._eval_condition(cond):
+                continue
+            return {
+                "loc": loc,
+                "remote_path": remote_path,
+                "local_path": local_path,
+                "bp": bp,
+            }
+        return None
+
+    async def _eval_condition(self, cond: str) -> bool:
+        """Evaluate a pending breakpoint's condition at the debuggee's
+        current compile-phase stop. Mirrors perl5db's own conditional-
+        breakpoint semantics (_DB__determine_if_we_should_break's
+        `$DB::signal |= 1 if do {$stop}`): a condition that dies aborts
+        the `if` before the assignment runs, so the breakpoint does NOT
+        fire -- fail-CLOSED. Confirmed empirically against a live
+        session: a real runtime `b file:line die 'x'` breakpoint never
+        fires and the debuggee runs to completion. helper() raises
+        PerlProtocolError on any payload carrying an "error" key
+        (cond_result always includes one when the eval died), so that
+        exception is exactly the die-during-condition case -- treat it
+        the same as a false condition.
+        """
+        cmd = (
+            ";{ local $@; my $r = eval { (" + cond + ") ? 1 : 0 }; "
+            "Devel::TdbHelper::cond_result($r, $@) }"
+        )
+        try:
+            payload = await self.session.helper(cmd)
+        except PerlProtocolError:
+            return False
+        return bool(payload.get("ok"))
+
+    async def _report_pending_hit(self, hit: dict) -> None:
+        """Report an early stop from _settle_to_run_phase the same way a
+        real breakpoint stop is reported: a `breakpoint` "changed" event
+        (verified:true, same shape _flush_pending_if_run already sends)
+        followed by a `stopped` event. Mirrors _emit_stopped's
+        refs/current_stop handling so the stack/variables views work at
+        this compile-phase stop. The pending entry is deliberately left
+        in self._pending_breakpoints (requirement 7): a BEGIN line never
+        executes again, so the eventual RUN-phase flush applying it for
+        real is harmless (it just arms a breakpoint that can never hit)
+        and _on_breakpoint_event's verified-state update is idempotent.
+        """
+        self.refs.reset()
+        self.current_stop = hit["loc"]
+        bp = hit["bp"]
+        self.send_event(
+            "breakpoint",
+            {
+                "reason": "changed",
+                "breakpoint": {
+                    "verified": True,
+                    "line": bp["line"],
+                    "source": {"path": hit["local_path"]},
+                },
+            },
+        )
+        self.send_event(
+            "stopped",
+            {"reason": "breakpoint", "threadId": 1, "allThreadsStopped": True},
+        )
 
     async def _flush_pending_if_run(self) -> None:
         if not self._pending_breakpoints or self.session is None:
@@ -559,7 +670,15 @@ class PerlDapServer:
         # so a stop reaching RUN phase there is caught by
         # _classify_and_emit_stop's reactive flush instead.
         if self._pending_breakpoints and self._not_ready() is None:
-            await self._settle_to_run_phase()
+            hit = await self._settle_to_run_phase()
+            if hit is not None:
+                self.current_stop = None
+                self.send_response(request)
+                self.send_event(
+                    "continued", {"threadId": 1, "allThreadsContinued": True}
+                )
+                await self._report_pending_hit(hit)
+                return
         await self._resume(request, "c")
 
     async def _on_next(self, request: Request) -> None:

--- a/src/tdb/adapters/perl/server.py
+++ b/src/tdb/adapters/perl/server.py
@@ -15,6 +15,7 @@ from typing import Any, Awaitable, Callable
 
 from tdb.dap.messages import Event, Request, Response, parse_message
 from tdb.dap.protocol import encode_message, read_message
+from tdb.dap.types import DEFERRED_VERIFICATION_MESSAGE
 
 from .refs import RefRegistry
 from .session import PerlProtocolError, PerlSession
@@ -308,16 +309,21 @@ class PerlDapServer:
         """`Devel::TdbHelper::location()`, auto-stepping past any stop
         that lands inside our own compile-phase shim.
 
-        Requirement: no stop may ever surface inside TdbCompile.pm --
-        it wraps DB::DB for the debuggee's whole lifetime (see that
-        module's own header comment on why it stays installed), and as
-        a defense-in-depth belt-and-suspenders on top of that module's
-        own fix, if a stray trap ever DOES land there, auto-step past
-        it (the same auto-step-out-to-caller pattern _on_attach already
-        uses for Devel::TdbRemote) rather than surfacing it as a user
-        stop. Bounded so a persistent leak can't hang tdb -- it would
-        instead fall through to the pre-existing "location() gave us
-        nothing usable" handling.
+        TdbCompile.pm's DB::DB wrapper self-uninstalls the instant
+        ${^GLOBAL_PHASE} leaves 'START' (see that module's own header
+        comment: leaving it installed with a `goto`-passthrough for the
+        rest of the process's life was tried and reliably OOM'd perl).
+        Self-uninstalling leaks exactly one stop at the
+        reassignment/goto line, inside TdbCompile.pm itself, during
+        that START->RUN transition. That stop is normally hidden by
+        `_user_frames` in helpers.pl (which skips frames whose package
+        is Devel::TdbCompile); this is the belt-and-suspenders backstop
+        on the adapter side -- if a stray trap ever DOES surface here
+        regardless, auto-step past it (the same auto-step-out-to-caller
+        pattern _on_attach already uses for Devel::TdbRemote) rather
+        than showing it as a user stop. Bounded so a persistent leak
+        can't hang tdb -- it would instead fall through to the
+        pre-existing "location() gave us nothing usable" handling.
         """
         loc = None
         for _ in range(5):
@@ -627,7 +633,20 @@ class PerlDapServer:
         # attaches), so this is a no-op there.
         if await self._current_phase() == "START":
             self._pending_breakpoints[remote_path] = (path, wanted)
-            results = [{"verified": False, "line": bp["line"]} for bp in wanted]
+            # DEFERRED_VERIFICATION_MESSAGE tells controller.py's
+            # _warn_unbound_breakpoints this verified:false is a deferral,
+            # not a genuine bind failure, so it doesn't fire its
+            # missing-debug-info warning here; _flush_pending_if_run sends
+            # the real answer as a `breakpoint` "changed" event once the
+            # compile phase settles (see requirement 5).
+            results = [
+                {
+                    "verified": False,
+                    "line": bp["line"],
+                    "message": DEFERRED_VERIFICATION_MESSAGE,
+                }
+                for bp in wanted
+            ]
             self.send_response(request, {"breakpoints": results})
             return
         # A later, non-deferred request for this same file supersedes

--- a/src/tdb/adapters/perl/session.py
+++ b/src/tdb/adapters/perl/session.py
@@ -57,6 +57,15 @@ class PerlSession:
     def pid(self) -> int | None:
         return self._process.pid if self._process else None
 
+    @property
+    def eof(self) -> bool:
+        """True once the debug socket has genuinely closed (read loop hit
+        EOF). Lets callers that force a `command("q")` to try to end the
+        session distinguish "it actually closed the connection" from "it
+        timed out / replied without dying" -- the two need different
+        follow-up handling (see server.py's `_eof_terminated` guard)."""
+        return self._eof
+
     async def wait_exit_code(self, timeout: float = 2.0) -> int:
         """Best-effort real exit code of the owned child (launch mode only).
 

--- a/src/tdb/adapters/perl/session.py
+++ b/src/tdb/adapters/perl/session.py
@@ -31,6 +31,11 @@ def helpers_path() -> str:
     return str(ref)
 
 
+def compile_shim_path() -> str:
+    ref = importlib.resources.files("tdb.adapters.perl") / "Devel" / "TdbCompile.pm"
+    return str(ref)
+
+
 class PerlSession:
     def __init__(
         self,
@@ -115,15 +120,36 @@ class PerlSession:
         # perl 5.40.1). This MUST match `program` below exactly, or
         # the filter silently never matches and the whole feature is
         # a no-op.
-        child_env["TDB_COMPILE_FILE"] = program
+        #
+        # Defensive existence check: as of this writing pyproject.toml's
+        # package-data does NOT list Devel/TdbCompile.pm (only
+        # helpers.pl and TdbRemote.pm), so a built wheel installed
+        # non-editable ships without this file. Passing -MDevel::TdbCompile
+        # unconditionally in that case makes perl abort at startup
+        # ("Can't locate Devel/TdbCompile.pm in @INC ... BEGIN failed") --
+        # launch mode would be entirely broken, not merely missing
+        # BEGIN-block stepping. Omit the -I/-M pair and degrade to a
+        # normal launch instead. The packaging fix (adding the file to
+        # pyproject.toml's package-data) is still required for the
+        # feature to actually work out of a wheel -- this only prevents
+        # a missing file from taking the whole adapter down.
         adapters_dir = os.path.dirname(helpers_path())
+        shim_path = compile_shim_path()
+        compile_shim_available = os.path.isfile(shim_path)
+        argv = [perl, "-d"]
+        if compile_shim_available:
+            child_env["TDB_COMPILE_FILE"] = program
+            argv += [f"-I{adapters_dir}", "-MDevel::TdbCompile"]
+        else:
+            log.warning(
+                "Devel::TdbCompile shim not found at %s -- compile-phase "
+                "(BEGIN-block) debugging is unavailable for this launch; "
+                "continuing with a normal launch.",
+                shim_path,
+            )
+        argv += [program, *args]
         self._process = await asyncio.create_subprocess_exec(
-            perl,
-            "-d",
-            f"-I{adapters_dir}",
-            "-MDevel::TdbCompile",
-            program,
-            *args,
+            *argv,
             cwd=cwd,
             env=child_env,
             stdin=asyncio.subprocess.DEVNULL,

--- a/src/tdb/adapters/perl/session.py
+++ b/src/tdb/adapters/perl/session.py
@@ -105,9 +105,23 @@ class PerlSession:
         port = server.sockets[0].getsockname()[1]
         child_env = dict(env or os.environ)
         child_env["PERLDB_OPTS"] = f"RemotePort=127.0.0.1:{port}"
+        # Devel::TdbCompile (this adapter's own compile-phase shim --
+        # see that module's header) arms perl5db to trap during
+        # perl's compile phase, so BEGIN blocks become steppable. It
+        # only traps statements belonging to `program`, filtered by
+        # comparing against exactly the string perl reports in
+        # `caller` for it -- which is argv's program path VERBATIM,
+        # not resolved/canonicalized (confirmed empirically against
+        # perl 5.40.1). This MUST match `program` below exactly, or
+        # the filter silently never matches and the whole feature is
+        # a no-op.
+        child_env["TDB_COMPILE_FILE"] = program
+        adapters_dir = os.path.dirname(helpers_path())
         self._process = await asyncio.create_subprocess_exec(
             perl,
             "-d",
+            f"-I{adapters_dir}",
+            "-MDevel::TdbCompile",
             program,
             *args,
             cwd=cwd,

--- a/src/tdb/adapters/perl/session.py
+++ b/src/tdb/adapters/perl/session.py
@@ -57,6 +57,27 @@ class PerlSession:
     def pid(self) -> int | None:
         return self._process.pid if self._process else None
 
+    async def wait_exit_code(self, timeout: float = 2.0) -> int:
+        """Best-effort real exit code of the owned child (launch mode only).
+
+        Attach mode has no owned child (`self._process` is None) -- always
+        0 there. In launch mode, perl5db parks at a live "?" prompt (or the
+        debug socket can close on a hard crash) slightly before the OS has
+        actually reaped the child, so this waits briefly rather than
+        assuming `returncode` is already populated. Bounded so a child that,
+        for whatever reason, never exits can't block the event loop
+        indefinitely -- falls back to 0 in that case.
+        """
+        if self._process is None:
+            return 0
+        if self._process.returncode is not None:
+            return self._process.returncode
+        try:
+            await asyncio.wait_for(self._process.wait(), timeout)
+        except asyncio.TimeoutError:
+            return 0
+        return self._process.returncode if self._process.returncode is not None else 0
+
     async def launch(
         self,
         program: str,

--- a/src/tdb/app.py
+++ b/src/tdb/app.py
@@ -36,6 +36,7 @@ from tdb.widgets.console_view import ConsoleView
 from tdb.widgets.evaluate_console import EvaluateConsole
 from tdb.widgets.menu_bar import MenuBar, _MenuDropdown
 from tdb.widgets.modals import (
+    DEFAULT_TRACEBACK_HEADER,
     _AboutModal,
     _DocumentationModal,
     _KeybindingsModal,
@@ -996,6 +997,7 @@ class TdbApp(_AppMessageRoutes, App):
                 exc,
                 self.panels.last_frames_text or "",
                 can_restart=self.panels.last_can_restart,
+                header=self.panels.last_header or DEFAULT_TRACEBACK_HEADER,
             ),
             callback=on_dismiss,
         )

--- a/src/tdb/app_handlers/dap_events.py
+++ b/src/tdb/app_handlers/dap_events.py
@@ -232,17 +232,12 @@ class DapEventCoordinator:
             # `current_frame_id` via `resolve_evaluate_frame_id`.
             state.set_stack(synthetic_frames, synthetic=True)
 
-        # Modal body: one "File ..." line per frame, outermost first
-        # (matches ParsedError.frames order).
-        frame_lines = [
-            f'  File "{frame.path}", line {frame.line}, in {frame.func}'
-            if frame.func
-            else f'  File "{frame.path}", line {frame.line}'
-            for frame in parsed.frames
-        ]
-        frames_text = (
-            "\n".join(frame_lines) if frame_lines else "  <no frames available>"
-        )
+        # Modal body: the parser's raw detail text (verbatim source
+        # snippets / chained-exception separator text for Python; the die
+        # message + call-frame lines for Perl) -- NOT rebuilt from
+        # `parsed.frames`, which only carries structured File/line/func
+        # data for the synthetic StackFrames above.
+        frames_text = parsed.detail
 
         def on_dismiss(result: str | None) -> None:
             if result == "restart":

--- a/src/tdb/app_handlers/dap_events.py
+++ b/src/tdb/app_handlers/dap_events.py
@@ -169,7 +169,8 @@ class DapEventCoordinator:
                 # the buffer to stabilize before parsing, otherwise the modal
                 # shows a partial traceback.
                 await self._wait_for_stderr_quiescent()
-                self._check_stderr_traceback()
+                exit_code = await self._wait_for_exit_code()
+                self._check_stderr_traceback(exit_code)
             self.app._update_ui_state()
         except Exception:
             log.exception("Error handling terminated event")
@@ -195,10 +196,40 @@ class DapEventCoordinator:
             if now >= deadline:
                 return
 
-    def _check_stderr_traceback(self) -> None:
+    async def _wait_for_exit_code(
+        self,
+        max_wait: float = 0.3,
+    ) -> int | None:
+        """Bounded wait for `state.last_exit_code` to be populated.
+
+        `terminated` and `exited` are separate DAP events and this coordinator
+        runs on `terminated`. Measured empirically (see task report): debugpy
+        emits `exited` BEFORE `terminated`, so `last_exit_code` is already set
+        by the time this runs. The perl adapter emits them in the opposite
+        order (`terminated` then `exited`, written back-to-back with no
+        `await` between them), so `exited` can still be in flight -- poll
+        briefly rather than assume. Falls back to whatever is present (often
+        still None) once `max_wait` elapses, e.g. if the adapter never sends
+        `exited` at all (either event is independently sufficient -- see
+        DebugController._on_terminated/_on_exited).
+        """
+        state = self.app.controller.state
+        deadline = asyncio.get_event_loop().time() + max_wait
+        while state.last_exit_code is None:
+            if asyncio.get_event_loop().time() >= deadline:
+                break
+            await asyncio.sleep(0.02)
+        return state.last_exit_code
+
+    def _check_stderr_traceback(self, exit_code: int | None = None) -> None:
         """If stderr contains a fatal error the active profile's parser
         recognizes, show it in a modal, build synthetic stack frames,
-        and navigate Code View to the deepest frame."""
+        and navigate Code View to the deepest frame.
+
+        `exit_code` is the debuggee's real DAP `exited` code if known by
+        the time this runs (see `_wait_for_exit_code`); passed straight
+        through to the profile's parser, which may ignore it (python) or
+        use it to gate fatality (perl)."""
         from tdb.dap.types import Source, StackFrame
 
         parse_error = self.app.controller.profile.presentation.parse_error
@@ -206,7 +237,7 @@ class DapEventCoordinator:
             return
 
         stderr = "".join(self.app._stderr_buffer)
-        parsed = parse_error(stderr)
+        parsed = parse_error(stderr, exit_code)
         if parsed is None:
             return
 

--- a/src/tdb/app_handlers/dap_events.py
+++ b/src/tdb/app_handlers/dap_events.py
@@ -245,12 +245,13 @@ class DapEventCoordinator:
         # DAP). ParsedError.frames is OUTERMOST-first (source order); the
         # parser does not do this inversion, so it happens here.
         state = self.app.controller.state
+        placeholder = self.app.controller.profile.presentation.frame_placeholder
         synthetic_frames: list[StackFrame] = []
         for i, frame in enumerate(reversed(parsed.frames)):
             synthetic_frames.append(
                 StackFrame(
                     id=i,
-                    name=frame.func or "<module>",
+                    name=frame.func or placeholder,
                     source=Source(path=frame.path, name=os.path.basename(frame.path)),
                     line=frame.line,
                 )

--- a/src/tdb/app_handlers/dap_events.py
+++ b/src/tdb/app_handlers/dap_events.py
@@ -12,25 +12,16 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import re
 from typing import TYPE_CHECKING
 
 from tdb.session.messages import DapOutput, DapStopped
 from tdb.widgets.console_view import ConsoleView
-from tdb.widgets.modals import _TracebackModal
+from tdb.widgets.modals import DEFAULT_TRACEBACK_HEADER, _TracebackModal
 
 if TYPE_CHECKING:
     from tdb.app import TdbApp
 
 log = logging.getLogger(__name__)
-
-
-# Pre-compiled at module level so repeated traceback parses don't
-# re-build the regex each time.
-_TB_FILE_RE = re.compile(
-    r'^\s*File "(.+)", line (\d+)(?:, in (.+))?',
-    re.MULTILINE,
-)
 
 
 class DapEventCoordinator:
@@ -140,6 +131,7 @@ class DapEventCoordinator:
         self.app.panels.last_exception_text = exception_text
         self.app.panels.last_frames_text = frames_text
         self.app.panels.last_can_restart = can_restart
+        self.app.panels.last_header = DEFAULT_TRACEBACK_HEADER
         self.app.push_screen(
             _TracebackModal(
                 exception_text,
@@ -204,63 +196,32 @@ class DapEventCoordinator:
                 return
 
     def _check_stderr_traceback(self) -> None:
-        """If stderr contains a Python traceback, show it in a modal,
-        build synthetic stack frames, and navigate Code View to the
-        deepest frame."""
+        """If stderr contains a fatal error the active profile's parser
+        recognizes, show it in a modal, build synthetic stack frames,
+        and navigate Code View to the deepest frame."""
         from tdb.dap.types import Source, StackFrame
 
-        stderr = "".join(self.app._stderr_buffer)
-        tb_header = "Traceback (most recent call last):"
-        if tb_header not in stderr:
+        parse_error = self.app.controller.profile.presentation.parse_error
+        if parse_error is None:
             return
 
-        # Capture from the FIRST traceback header to the end, so chained
-        # exceptions ("The above exception was the direct cause..." /
-        # "During handling of the above exception...") are preserved in full.
-        tb_start = stderr.find(tb_header)
-        tb_text = stderr[tb_start:].rstrip()
+        stderr = "".join(self.app._stderr_buffer)
+        parsed = parse_error(stderr)
+        if parsed is None:
+            return
 
-        # Split into individual traceback blocks (one per chained exception).
-        block_starts = [m.start() for m in re.finditer(re.escape(tb_header), tb_text)]
-        blocks: list[str] = []
-        for i, s in enumerate(block_starts):
-            e = block_starts[i + 1] if i + 1 < len(block_starts) else len(tb_text)
-            blocks.append(tb_text[s:e].rstrip())
-
-        # Synthetic stack frames come from the LAST block — that is the
-        # exception that actually terminated the process (Python prints
-        # cause/context first, final exception last).
-        final_block = blocks[-1] if blocks else tb_text
-        matches = list(_TB_FILE_RE.finditer(final_block))
-
-        # The exception line is the last non-empty, non-indented line of the
-        # final block (Python prints it after all "File" frames).
-        lines = final_block.split("\n")
-        exception_text = ""
-        for line in reversed(lines):
-            stripped = line.strip()
-            if not stripped:
-                continue
-            if stripped.startswith("File ") or stripped.startswith("Traceback "):
-                break
-            if line.startswith("    ") or line.startswith("\t"):
-                continue
-            exception_text = stripped
-            break
-
-        # Build synthetic stack frames (reversed: deepest = index 0, like DAP)
+        # Build synthetic stack frames (reversed: deepest = index 0, like
+        # DAP). ParsedError.frames is OUTERMOST-first (source order); the
+        # parser does not do this inversion, so it happens here.
         state = self.app.controller.state
         synthetic_frames: list[StackFrame] = []
-        for i, m in enumerate(reversed(matches)):
-            path = m.group(1)
-            line = int(m.group(2))
-            func = m.group(3) or "<module>"
+        for i, frame in enumerate(reversed(parsed.frames)):
             synthetic_frames.append(
                 StackFrame(
                     id=i,
-                    name=func,
-                    source=Source(path=path, name=os.path.basename(path)),
-                    line=line,
+                    name=frame.func or "<module>",
+                    source=Source(path=frame.path, name=os.path.basename(frame.path)),
+                    line=frame.line,
                 )
             )
 
@@ -271,25 +232,34 @@ class DapEventCoordinator:
             # `current_frame_id` via `resolve_evaluate_frame_id`.
             state.set_stack(synthetic_frames, synthetic=True)
 
-        # Modal body: show every block's body (after its header line) so
-        # chained exception separator text is preserved.
-        first_header_end = tb_text.index("\n") + 1 if "\n" in tb_text else len(tb_text)
-        frames_text = tb_text[first_header_end:].rstrip()
+        # Modal body: one "File ..." line per frame, outermost first
+        # (matches ParsedError.frames order).
+        frame_lines = [
+            f'  File "{frame.path}", line {frame.line}, in {frame.func}'
+            if frame.func
+            else f'  File "{frame.path}", line {frame.line}'
+            for frame in parsed.frames
+        ]
+        frames_text = (
+            "\n".join(frame_lines) if frame_lines else "  <no frames available>"
+        )
 
         def on_dismiss(result: str | None) -> None:
             if result == "restart":
                 self.app._restart_session()
 
-        exc_label = exception_text or "Program crashed"
+        exc_label = parsed.message or "Program crashed"
         can_restart = self.app.controller.supports_restart
         self.app.panels.last_exception_text = exc_label
         self.app.panels.last_frames_text = frames_text
         self.app.panels.last_can_restart = can_restart
+        self.app.panels.last_header = parsed.header
         self.app.push_screen(
             _TracebackModal(
                 exc_label,
                 frames_text,
                 can_restart=can_restart,
+                header=parsed.header,
             ),
             callback=on_dismiss,
         )

--- a/src/tdb/app_handlers/ui_panels.py
+++ b/src/tdb/app_handlers/ui_panels.py
@@ -50,6 +50,7 @@ class UIPanels:
     last_exception_text: str | None = None
     last_frames_text: str | None = None
     last_can_restart: bool = False
+    last_header: str | None = None
 
     def clear(self) -> None:
         """Drop all modal refs and reset transient flags. Called on
@@ -61,3 +62,4 @@ class UIPanels:
         self.last_exception_text = None
         self.last_frames_text = None
         self.last_can_restart = False
+        self.last_header = None

--- a/src/tdb/dap/types.py
+++ b/src/tdb/dap/types.py
@@ -21,6 +21,17 @@ class Source:
         )
 
 
+# A setBreakpoints response Breakpoint carries this exact message when an
+# adapter has deferred real verification to a later point instead of
+# reporting a genuine bind failure (perl's compile-phase breakpoint
+# deferral -- see adapters/perl/server.py's _on_setBreakpoints -- is the
+# only current producer). Breakpoints carrying it are always followed by
+# a `breakpoint` "changed" event once resolved; controller.py's
+# _warn_unbound_breakpoints treats its presence as "the adapter already
+# explained itself" and skips its own missing-debug-info guess-warning.
+DEFERRED_VERIFICATION_MESSAGE = "not yet verified: still compiling"
+
+
 @dataclass
 class Breakpoint:
     id: int = 0
@@ -51,6 +62,14 @@ class SourceBreakpoint:
     # tdb-local flag; not part of DAP wire format. False for -t/--to-line
     # breakpoints, which are excluded from breakpoints.json on save.
     persist: bool = True
+    # tdb-local flag; not part of DAP wire format. Mirrors the adapter's
+    # last-reported verified state for this line -- True until told
+    # otherwise so most (synchronously-verifying) adapters never touch
+    # it. Kept current by controller.py's setBreakpoints response
+    # handling and its `breakpoint` "changed" event handler (the latter
+    # is how an adapter that defers verification, e.g. perl's
+    # compile-phase breakpoint deferral, corrects it after the fact).
+    verified: bool = True
 
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {"line": self.line}

--- a/src/tdb/languages/base.py
+++ b/src/tdb/languages/base.py
@@ -151,6 +151,15 @@ class Presentation:
     # parser (yet).
     parse_error: Callable[[str, "int | None"], "ParsedError | None"] | None = None
 
+    # Synthetic-stack-frame display name for an ErrorFrame whose `func`
+    # is "" (the language doesn't name a function for that frame, e.g.
+    # top-level/compile-time code). Python's fatal-error frames use this
+    # historical convention for module-level code; other languages have
+    # their own (perl's live stackTrace already falls back to "main" --
+    # see adapters/perl/server.py -- so its error-modal synthetic frames
+    # match that instead of showing Python's "<module>").
+    frame_placeholder: str = "<module>"
+
 
 @dataclass(frozen=True)
 class ProfileCapabilities:

--- a/src/tdb/languages/base.py
+++ b/src/tdb/languages/base.py
@@ -149,7 +149,7 @@ class Presentation:
     # parsers with an unambiguous signal of their own (python's
     # traceback header) accept and ignore it. None -> language has no
     # parser (yet).
-    parse_error: Callable[[str, "int | None"], "ParsedError | None"] | None = None
+    parse_error: Callable[[str, int | None], ParsedError | None] | None = None
 
     # Synthetic-stack-frame display name for an ErrorFrame whose `func`
     # is "" (the language doesn't name a function for that frame, e.g.

--- a/src/tdb/languages/base.py
+++ b/src/tdb/languages/base.py
@@ -141,8 +141,15 @@ class Presentation:
     lexer: str = "text"
 
     # Parse a language's raw stderr into a ParsedError, or None if no
-    # fatal error is present. None -> language has no parser (yet).
-    parse_error: Callable[[str], "ParsedError | None"] | None = None
+    # fatal error is present. `exit_code` is the debuggee's real DAP
+    # `exited` code when it's available by the time parsing runs (None
+    # if it hasn't arrived yet, or the language has no owned child to
+    # report one for, e.g. attach mode) -- consulted only by parsers
+    # that need it to disambiguate fatal-vs-non-fatal output (perl);
+    # parsers with an unambiguous signal of their own (python's
+    # traceback header) accept and ignore it. None -> language has no
+    # parser (yet).
+    parse_error: Callable[[str, "int | None"], "ParsedError | None"] | None = None
 
 
 @dataclass(frozen=True)

--- a/src/tdb/languages/base.py
+++ b/src/tdb/languages/base.py
@@ -123,6 +123,14 @@ class ParsedError:
     header: str  # modal's first line, e.g. "Traceback (most recent call last):"
     message: str  # e.g. "ZeroDivisionError: division by zero"
     frames: list[ErrorFrame]  # OUTERMOST-first (source order), same as Python prints
+    # Raw display text for the modal body (below the header line): the
+    # language's own error text, verbatim where possible, so source
+    # snippets / chained-exception separator sentences / etc. aren't
+    # lost. NOT reconstructed from `frames` -- built directly off the
+    # original stderr text by the parser. `frames` stays the
+    # structured data `_check_stderr_traceback` uses to build synthetic
+    # DAP StackFrames.
+    detail: str
 
 
 @dataclass(frozen=True)

--- a/src/tdb/languages/base.py
+++ b/src/tdb/languages/base.py
@@ -108,11 +108,33 @@ class AdapterSpec:
 
 
 @dataclass(frozen=True)
+class ErrorFrame:
+    """One stack frame parsed out of a language's fatal-error output."""
+
+    path: str
+    line: int
+    func: str  # "" when the language doesn't name one
+
+
+@dataclass(frozen=True)
+class ParsedError:
+    """A language's fatal-error text, parsed into modal-ready pieces."""
+
+    header: str  # modal's first line, e.g. "Traceback (most recent call last):"
+    message: str  # e.g. "ZeroDivisionError: division by zero"
+    frames: list[ErrorFrame]  # OUTERMOST-first (source order), same as Python prints
+
+
+@dataclass(frozen=True)
 class Presentation:
     """Language-specific display knobs, consumed by widgets."""
 
     # Rich/pygments lexer name for the Code View.
     lexer: str = "text"
+
+    # Parse a language's raw stderr into a ParsedError, or None if no
+    # fatal error is present. None -> language has no parser (yet).
+    parse_error: Callable[[str], "ParsedError | None"] | None = None
 
 
 @dataclass(frozen=True)

--- a/src/tdb/languages/errors.py
+++ b/src/tdb/languages/errors.py
@@ -20,7 +20,7 @@ _TB_FILE_RE = re.compile(
 )
 
 
-def parse_python_error(stderr: str) -> ParsedError | None:
+def parse_python_error(stderr: str, exit_code: int | None = None) -> ParsedError | None:
     """Parse a Python traceback out of raw stderr text.
 
     Bails (returns None) unless the standard traceback header is
@@ -29,6 +29,14 @@ def parse_python_error(stderr: str) -> ParsedError | None:
     split into blocks; the LAST block is used, since that is the
     exception that actually terminated the process (Python prints
     cause/context first, final exception last).
+
+    ``exit_code`` is accepted for signature parity with
+    ``Presentation.parse_error`` (and with ``parse_perl_error``, which
+    DOES consult it) but is intentionally IGNORED here: the traceback
+    header is already an unambiguous fatal-error signal, and a program
+    can legitimately print a caught traceback (e.g. via
+    ``traceback.print_exc()``) and still exit 0 -- gating on exit code
+    would misclassify that as "no error".
     """
     tb_header = "Traceback (most recent call last):"
     if tb_header not in stderr:
@@ -110,9 +118,12 @@ _PERL_TERMINATOR_RE = re.compile(
     r"^(BEGIN failed--compilation aborted|Compilation failed in require)\b"
 )
 
-# Known non-fatal perl warning openers. Only consulted for a "lone" first
-# line (nothing else follows) -- see the module-level note in
-# parse_perl_error for why that case is ambiguous.
+# Known non-fatal perl warning openers. Fragile by nature (any warning
+# opener not on this list is misclassified as fatal) -- only used as the
+# LAST-RESORT fallback in parse_perl_error when the real exit code isn't
+# available (exit_code is None: attach mode, or the `exited` DAP event
+# never arrived). When exit_code IS available, fatality is decided
+# directly from it instead and this list is not consulted at all.
 _PERL_WARNING_PREFIXES = (
     "Use of uninitialized value",
     "Use of each",
@@ -122,14 +133,21 @@ _PERL_WARNING_PREFIXES = (
 )
 
 
-def parse_perl_error(stderr: str) -> ParsedError | None:
+def parse_perl_error(stderr: str, exit_code: int | None = None) -> ParsedError | None:
     """Parse a fatal perl die/error out of raw stderr text.
 
     A lone `... at FILE line N.` line is structurally identical whether
     perl is reporting a fatal die or a non-fatal warning (e.g. "Use of
     uninitialized value ... at x.pl line 10."), so a bare regex match on
-    the first line is not enough to call it fatal. This function treats
-    stderr as fatal when it finds a "died"-shaped terminator:
+    the first line is not enough to call it fatal on its own.
+
+    The primary fatality signal is the real process exit code: when
+    ``exit_code`` is not None, stderr shaped like a perl error/warning is
+    fatal exactly when ``exit_code != 0`` -- perl warnings never set a
+    non-zero exit code, so this is deterministic and needs no text
+    heuristics. When ``exit_code`` is None (attach mode has no owned
+    child to report one for, or the `exited` DAP event hasn't arrived by
+    parse time), fall back to the old shape-based heuristic:
 
       - the first line is the ONLY content (no frames, no scaffolding)
         and its message does not open with a known warning phrase, or
@@ -185,9 +203,17 @@ def parse_perl_error(stderr: str) -> ParsedError | None:
         if _PERL_TERMINATOR_RE.match(ln):
             has_terminator = True
 
-    if non_empty_rest:
+    if exit_code is not None:
+        # Deterministic: perl warnings never produce a non-zero exit, so
+        # the real exit code alone settles fatality -- no text heuristics
+        # needed, and none of the fragile-prefix false negatives from the
+        # old denylist are possible.
+        fatal = exit_code != 0
+    elif non_empty_rest:
         fatal = has_terminator or bool(call_frames)
     else:
+        # exit_code is None: last-resort fallback (see _PERL_WARNING_PREFIXES
+        # comment above).
         fatal = not message.startswith(_PERL_WARNING_PREFIXES)
 
     if not fatal:

--- a/src/tdb/languages/errors.py
+++ b/src/tdb/languages/errors.py
@@ -78,3 +78,106 @@ def parse_python_error(stderr: str) -> ParsedError | None:
         message=exception_text,
         frames=frames,
     )
+
+
+# First line of a fatal perl die/error, e.g.
+#   "Illegal division by zero at /w/has_begin.pl line 10."
+# Also matches plain warnings, which have the identical trailing-location
+# shape (see _PERL_WARNING_PREFIXES below for how those are told apart).
+_PERL_LOC_RE = re.compile(r"^(.*) at (\S+) line (\d+)\.\s*$")
+
+# A `\t<SUB>() called at <FILE> line <N>` call-frame line, printed by perl
+# when a die/error propagates out of nested subs or a BEGIN block. No
+# trailing period (unlike the message's own location line).
+_PERL_FRAME_RE = re.compile(r"^\t(.+?) called at (\S+) line (\d+)\s*$")
+
+# perl's own compile-phase terminators: printed after a BEGIN block or a
+# `require`d module dies at compile time. Their presence is unambiguous
+# proof the process is dying, even when frame lines are also present.
+_PERL_TERMINATOR_RE = re.compile(
+    r"^(BEGIN failed--compilation aborted|Compilation failed in require)\b"
+)
+
+# Known non-fatal perl warning openers. Only consulted for a "lone" first
+# line (nothing else follows) -- see the module-level note in
+# parse_perl_error for why that case is ambiguous.
+_PERL_WARNING_PREFIXES = (
+    "Use of uninitialized value",
+    "Use of each",
+    'Argument "',
+    "Possible unintended interpolation",
+    "Odd number of elements",
+)
+
+
+def parse_perl_error(stderr: str) -> ParsedError | None:
+    """Parse a fatal perl die/error out of raw stderr text.
+
+    A lone `... at FILE line N.` line is structurally identical whether
+    perl is reporting a fatal die or a non-fatal warning (e.g. "Use of
+    uninitialized value ... at x.pl line 10."), so a bare regex match on
+    the first line is not enough to call it fatal. This function treats
+    stderr as fatal when it finds a "died"-shaped terminator:
+
+      - the first line is the ONLY content (no frames, no scaffolding)
+        and its message does not open with a known warning phrase, or
+      - a `\\t<SUB> called at ...` call-frame line follows (die
+        propagated out of a sub/BEGIN block), or
+      - a `BEGIN failed--compilation aborted` / `Compilation failed in
+        require` terminator line is present.
+
+    Frames are built from every call-frame line (skipping perl's own
+    `eval {...} called at` compile scaffolding) plus the innermost
+    location from the first line, reordered to OUTERMOST-first to match
+    Python's convention: perl prints call frames innermost-caller-first,
+    so they are reversed, then the innermost/failing frame is appended
+    last.
+    """
+    lines = stderr.splitlines()
+    if not lines:
+        return None
+
+    loc_match = _PERL_LOC_RE.match(lines[0])
+    if not loc_match:
+        return None
+
+    message = loc_match.group(1)
+    inner_path = loc_match.group(2)
+    inner_line = int(loc_match.group(3))
+
+    rest = lines[1:]
+    non_empty_rest = [ln for ln in rest if ln.strip()]
+
+    call_frames: list[ErrorFrame] = []
+    has_terminator = False
+    for ln in rest:
+        frame_match = _PERL_FRAME_RE.match(ln)
+        if frame_match:
+            func_raw = frame_match.group(1)
+            if func_raw == "eval {...}" or func_raw.startswith("eval "):
+                continue
+            func = func_raw[:-2] if func_raw.endswith("()") else func_raw
+            call_frames.append(
+                ErrorFrame(
+                    path=frame_match.group(2),
+                    line=int(frame_match.group(3)),
+                    func=func,
+                )
+            )
+            continue
+        if _PERL_TERMINATOR_RE.match(ln):
+            has_terminator = True
+
+    if non_empty_rest:
+        fatal = has_terminator or bool(call_frames)
+    else:
+        fatal = not message.startswith(_PERL_WARNING_PREFIXES)
+
+    if not fatal:
+        return None
+
+    frames = list(reversed(call_frames)) + [
+        ErrorFrame(path=inner_path, line=inner_line, func="")
+    ]
+
+    return ParsedError(header="Perl error:", message=message, frames=frames)

--- a/src/tdb/languages/errors.py
+++ b/src/tdb/languages/errors.py
@@ -207,7 +207,10 @@ def parse_perl_error(stderr: str, exit_code: int | None = None) -> ParsedError |
         # Deterministic: perl warnings never produce a non-zero exit, so
         # the real exit code alone settles fatality -- no text heuristics
         # needed, and none of the fragile-prefix false negatives from the
-        # old denylist are possible.
+        # old denylist are possible. Note the `loc_match` check above still
+        # gates everything: a nonzero exit with stderr that doesn't even
+        # look like a perl error/warning line correctly returns None here
+        # rather than fabricating a message from unrelated text.
         fatal = exit_code != 0
     elif non_empty_rest:
         fatal = has_terminator or bool(call_frames)

--- a/src/tdb/languages/errors.py
+++ b/src/tdb/languages/errors.py
@@ -73,10 +73,22 @@ def parse_python_error(stderr: str) -> ParsedError | None:
         for m in matches
     ]
 
+    # detail: everything after the FIRST header line, verbatim, to the
+    # end of stderr -- preserves source-snippet lines and, for chained
+    # exceptions, the "The above exception was the direct cause..." /
+    # "During handling of the above exception..." separator sentences
+    # and the repeated inner header line. This is intentionally NOT
+    # rebuilt from `frames` (which only carries structured File/line/func
+    # data from the LAST block) -- it is the same raw-text slice the
+    # pre-refactor inline code used for the modal body.
+    first_header_end = tb_text.index("\n") + 1 if "\n" in tb_text else len(tb_text)
+    detail = tb_text[first_header_end:].rstrip()
+
     return ParsedError(
         header=tb_header,
         message=exception_text,
         frames=frames,
+        detail=detail,
     )
 
 
@@ -149,6 +161,10 @@ def parse_perl_error(stderr: str) -> ParsedError | None:
     non_empty_rest = [ln for ln in rest if ln.strip()]
 
     call_frames: list[ErrorFrame] = []
+    # Raw call-frame lines (verbatim, in the order perl printed them --
+    # innermost-caller-first), for `detail`. Excludes perl's own `eval
+    # {...} called at` scaffolding, same as `call_frames`.
+    detail_frame_lines: list[str] = []
     has_terminator = False
     for ln in rest:
         frame_match = _PERL_FRAME_RE.match(ln)
@@ -164,6 +180,7 @@ def parse_perl_error(stderr: str) -> ParsedError | None:
                     func=func,
                 )
             )
+            detail_frame_lines.append(ln)
             continue
         if _PERL_TERMINATOR_RE.match(ln):
             has_terminator = True
@@ -180,4 +197,10 @@ def parse_perl_error(stderr: str) -> ParsedError | None:
         ErrorFrame(path=inner_path, line=inner_line, func="")
     ]
 
-    return ParsedError(header="Perl error:", message=message, frames=frames)
+    # detail: the die message plus its raw `\t... called at ...` frame
+    # lines (verbatim, scaffolding excluded), for the modal body.
+    detail = "\n".join([lines[0], *detail_frame_lines])
+
+    return ParsedError(
+        header="Perl error:", message=message, frames=frames, detail=detail
+    )

--- a/src/tdb/languages/errors.py
+++ b/src/tdb/languages/errors.py
@@ -1,0 +1,80 @@
+"""Language-specific fatal-error parsers, behind Presentation.parse_error.
+
+Each parser turns a debuggee's raw stderr text into a ParsedError (or
+None if no fatal error is present), so app_handlers/dap_events.py can
+build the traceback modal and synthetic stack frames without knowing
+which language produced the output.
+"""
+
+from __future__ import annotations
+
+import re
+
+from tdb.languages.base import ErrorFrame, ParsedError
+
+# Pre-compiled at module level so repeated traceback parses don't
+# re-build the regex each time.
+_TB_FILE_RE = re.compile(
+    r'^\s*File "(.+)", line (\d+)(?:, in (.+))?',
+    re.MULTILINE,
+)
+
+
+def parse_python_error(stderr: str) -> ParsedError | None:
+    """Parse a Python traceback out of raw stderr text.
+
+    Bails (returns None) unless the standard traceback header is
+    present. Chained tracebacks ("The above exception was the direct
+    cause..." / "During handling of the above exception...") are
+    split into blocks; the LAST block is used, since that is the
+    exception that actually terminated the process (Python prints
+    cause/context first, final exception last).
+    """
+    tb_header = "Traceback (most recent call last):"
+    if tb_header not in stderr:
+        return None
+
+    # Capture from the FIRST traceback header to the end, so chained
+    # exceptions ("The above exception was the direct cause..." /
+    # "During handling of the above exception...") are preserved in full.
+    tb_start = stderr.find(tb_header)
+    tb_text = stderr[tb_start:].rstrip()
+
+    # Split into individual traceback blocks (one per chained exception).
+    block_starts = [m.start() for m in re.finditer(re.escape(tb_header), tb_text)]
+    blocks: list[str] = []
+    for i, s in enumerate(block_starts):
+        e = block_starts[i + 1] if i + 1 < len(block_starts) else len(tb_text)
+        blocks.append(tb_text[s:e].rstrip())
+
+    # Synthetic stack frames come from the LAST block — that is the
+    # exception that actually terminated the process (Python prints
+    # cause/context first, final exception last).
+    final_block = blocks[-1] if blocks else tb_text
+    matches = list(_TB_FILE_RE.finditer(final_block))
+
+    # The exception line is the last non-empty, non-indented line of the
+    # final block (Python prints it after all "File" frames).
+    lines = final_block.split("\n")
+    exception_text = ""
+    for line in reversed(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("File ") or stripped.startswith("Traceback "):
+            break
+        if line.startswith("    ") or line.startswith("\t"):
+            continue
+        exception_text = stripped
+        break
+
+    frames = [
+        ErrorFrame(path=m.group(1), line=int(m.group(2)), func=m.group(3) or "<module>")
+        for m in matches
+    ]
+
+    return ParsedError(
+        header=tb_header,
+        message=exception_text,
+        frames=frames,
+    )

--- a/src/tdb/languages/perl.py
+++ b/src/tdb/languages/perl.py
@@ -25,6 +25,7 @@ from tdb.languages.base import (
     Presentation,
     ProfileCapabilities,
 )
+from tdb.languages.errors import parse_perl_error
 
 
 class PerlAdapter(AdapterSpec):
@@ -93,6 +94,6 @@ def build_perl_profile(
         id="perl",
         display_name="Perl",
         adapter=PerlAdapter(perl_executable=(adapter_paths or {}).get("perl")),
-        presentation=Presentation(lexer="perl"),
+        presentation=Presentation(lexer="perl", parse_error=parse_perl_error),
         capabilities=ProfileCapabilities(),
     )

--- a/src/tdb/languages/perl.py
+++ b/src/tdb/languages/perl.py
@@ -94,6 +94,8 @@ def build_perl_profile(
         id="perl",
         display_name="Perl",
         adapter=PerlAdapter(perl_executable=(adapter_paths or {}).get("perl")),
-        presentation=Presentation(lexer="perl", parse_error=parse_perl_error),
+        presentation=Presentation(
+            lexer="perl", parse_error=parse_perl_error, frame_placeholder="main"
+        ),
         capabilities=ProfileCapabilities(),
     )

--- a/src/tdb/languages/python.py
+++ b/src/tdb/languages/python.py
@@ -14,6 +14,7 @@ from tdb.languages.base import (
     Presentation,
     ProfileCapabilities,
 )
+from tdb.languages.errors import parse_python_error
 
 
 class DebugpyAdapter(AdapterSpec):
@@ -104,7 +105,7 @@ def build_python_profile(
         id="python",
         display_name="Python",
         adapter=DebugpyAdapter(),
-        presentation=Presentation(lexer="python"),
+        presentation=Presentation(lexer="python", parse_error=parse_python_error),
         capabilities=ProfileCapabilities(
             compute_step_units=compute_step_units,
             child_process_strategy="debugpy",

--- a/src/tdb/session/controller.py
+++ b/src/tdb/session/controller.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from tdb.dap.client import DAPClient
 from tdb.dap.messages import Event
-from tdb.dap.types import Breakpoint, SourceBreakpoint
+from tdb.dap.types import DEFERRED_VERIFICATION_MESSAGE, Breakpoint, SourceBreakpoint
 from .event_bus import DebugEventHandler
 from .state import DebugState, SessionPhase
 
@@ -157,13 +157,28 @@ class DebugController:
         Deliberately a no-op when `result` is empty (e.g. sending an
         empty breakpoint list to disable/clear) — there's nothing to
         warn about when no breakpoints were requested at all.
+
+        Also a no-op when an unverified breakpoint carries
+        DEFERRED_VERIFICATION_MESSAGE: the adapter has already explained
+        that verification is merely deferred (e.g. perl's compile-phase
+        breakpoint deferral), not failed, and will correct the state via
+        a `breakpoint` "changed" event once it settles (see
+        _on_breakpoint_event) — guessing "-g?" on top of that would be
+        wrong.
         """
-        if result and all(not bp.verified for bp in result):
-            self.event_handler.on_output(
-                f"warning: no breakpoints bound in {source_path} — "
-                f"was the program compiled with debug info (-g)?\n",
-                "console",
-            )
+        if not result:
+            return
+        if any(bp.message == DEFERRED_VERIFICATION_MESSAGE for bp in result):
+            return
+        if all(not bp.verified for bp in result):
+            self._emit_unbound_warning(source_path)
+
+    def _emit_unbound_warning(self, source_path: str) -> None:
+        self.event_handler.on_output(
+            f"warning: no breakpoints bound in {source_path} — "
+            f"was the program compiled with debug info (-g)?\n",
+            "console",
+        )
 
     async def _send_breakpoints(
         self, source_path: str, bps: list[SourceBreakpoint]
@@ -185,6 +200,7 @@ class DebugController:
         self.client.on_event("exited", self._on_exited)
         self.client.on_event("output", self._on_output)
         self.client.on_event("initialized", self._on_initialized)
+        self.client.on_event("breakpoint", self._on_breakpoint_event)
         # Child process debugging: ChildProcessManager registers its
         # own debugpyAttach handler that fires _spawn_bg(_attach(...)).
         # This is a debugpy-proprietary mechanism (the `debugpyAttach`
@@ -957,6 +973,38 @@ class DebugController:
         if self._terminal is not None and category in ("stdout", "stderr"):
             return
         self.event_handler.on_output(text, category)
+
+    def _on_breakpoint_event(self, event: Event) -> None:
+        """Corrects a breakpoint's stored verified state after an adapter
+        deferred it at setBreakpoints time (plan requirement 5's UI
+        half). perl's compile-phase breakpoint deferral is the only
+        current producer: it answers verified:false with
+        DEFERRED_VERIFICATION_MESSAGE at setBreakpoints time (see
+        _warn_unbound_breakpoints), then emits this "changed" event with
+        the real, resolved verified state once the compile phase
+        settles. Without this handler that correction was silently
+        dropped and stale unverified state could never be told apart
+        from a genuine bind failure after the fact.
+        """
+        body = event.body or {}
+        if body.get("reason") != "changed":
+            return
+        bp = body.get("breakpoint", {})
+        source_path = bp.get("source", {}).get("path")
+        line = bp.get("line")
+        if source_path is None or line is None:
+            return
+        bps = self.state.breakpoints.get(source_path)
+        if not bps:
+            return
+        matched = [sbp for sbp in bps if sbp.line == line]
+        if not matched:
+            return
+        for sbp in matched:
+            sbp.verified = bool(bp.get("verified", False))
+        enabled = self._enabled_bps(bps)
+        if enabled and all(not sbp.verified for sbp in enabled):
+            self._emit_unbound_warning(source_path)
 
     # --- Child process debugging ---
     # Per-child DAPClient lifecycle (attach, stopped-event handling,

--- a/src/tdb/session/controller.py
+++ b/src/tdb/session/controller.py
@@ -942,6 +942,7 @@ class DebugController:
         # disconnects). Transition to TERMINATED on both so the guards
         # engage no matter which event we get.
         self.state.transition_to(SessionPhase.TERMINATED)
+        self.state.last_exit_code = exit_code
         self._stopped_event.set()
         self.event_handler.on_exited(exit_code)
 

--- a/src/tdb/session/state.py
+++ b/src/tdb/session/state.py
@@ -67,6 +67,13 @@ class DebugState:
     # Reason for the last stop (breakpoint / step / exception / pause / etc.).
     stop_reason: str | None = None
 
+    # The debuggee's real exit code, set by the DAP `exited` event. None
+    # until `exited` arrives (it may never arrive at all -- `terminated`
+    # and `exited` are independent events, see DebugController._on_*).
+    # Consulted by DapEventCoordinator._check_stderr_traceback to gate
+    # the perl fatal-error parser.
+    last_exit_code: int | None = None
+
     # Per-frame scope lists, keyed by frame.id. Populated only in post-mortem.
     frame_scopes: dict[int, list[Scope]] = field(default_factory=dict)
 

--- a/src/tdb/widgets/modals.py
+++ b/src/tdb/widgets/modals.py
@@ -339,6 +339,13 @@ class _OpenFileModal(ModalScreen[str | None]):
         self.dismiss(None)
 
 
+# Default modal header, used when a call site doesn't supply one (the
+# live DAP "stopped: exception" path, which is Python/debugpy-only
+# today) and as the fallback for `_TracebackModal.__init__`'s `header`
+# parameter.
+DEFAULT_TRACEBACK_HEADER = "Traceback (most recent call last):"
+
+
 class _TracebackModal(ModalScreen[str | None]):
     """Scrollable modal showing a full exception traceback."""
 
@@ -368,21 +375,24 @@ class _TracebackModal(ModalScreen[str | None]):
         exception_text: str,
         frames_text: str,
         can_restart: bool = True,
+        header: str = DEFAULT_TRACEBACK_HEADER,
     ) -> None:
         super().__init__()
         self._exception_text = exception_text
         self._frames_text = frames_text
         self._can_restart = can_restart
+        self._header = header
 
     def compose(self):
         # Escape bare '[' so exception messages like "list[int]" or
         # chained-traceback separator text don't get parsed as Rich markup.
         exc_safe = self._exception_text.replace("[", r"\[")
         frames_safe = self._frames_text.replace("[", r"\[")
+        header_safe = self._header.replace("[", r"\[")
         lines = []
         lines.append(f"[bold red]{exc_safe}[/bold red]")
         lines.append("")
-        lines.append("[bold]Traceback (most recent call last):[/bold]")
+        lines.append(f"[bold]{header_safe}[/bold]")
         lines.append(frames_safe)
         lines.append("")
         if self._can_restart:

--- a/tests/integration/test_perl_begin_blocks.py
+++ b/tests/integration/test_perl_begin_blocks.py
@@ -1,0 +1,327 @@
+"""BEGIN blocks are steppable: tdb stops during perl's compile phase."""
+
+import asyncio
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, "tests/integration")
+from perl_adapter_harness import AdapterClient
+
+from tdb.adapters.perl.protocol import StreamParser
+from tdb.adapters.perl.session import PerlProtocolError, PerlSession, helpers_path
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("perl") is None
+    or subprocess.run(["perl", "-e", "require v5.18"]).returncode != 0,
+    reason="perl >= 5.18 required",
+)
+
+WITH_BEGIN = """use strict;
+use warnings;
+
+BEGIN {
+    my $x = 10;
+    my $y = $x * 2;
+    print STDERR "begin $x $y\\n";
+}
+
+my $b = 20;
+print STDERR "main $b\\n";
+
+END {
+    my $z = 99;
+    print STDERR "end $z\\n";
+}
+"""
+
+NO_PRAGMAS = 'my $a = 1;\nmy $b = 2;\nprint STDERR "x\\n";\n'
+
+
+async def _launch(tmp_path, source, name="p.pl"):
+    prog = tmp_path / name
+    prog.write_text(source)
+    c = AdapterClient()
+    await c.start()
+    await c.request("initialize", {})
+    c.send("launch", {"program": str(prog), "cwd": str(tmp_path)})
+    await c.wait_event("initialized")
+    await c.request("configurationDone", {})
+    await c.wait_event("stopped")
+    return c, str(prog)
+
+
+async def _where(c):
+    st = await c.request("stackTrace", {"threadId": 1})
+    f = st["body"]["stackFrames"][0]
+    return f["source"]["path"], f["line"], f["name"]
+
+
+async def test_first_stop_is_compile_phase_statement(tmp_path):
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        path, line, _ = await _where(c)
+        assert path == prog
+        assert line == 1  # `use strict;` -- a compile-time statement
+    finally:
+        await c.stop()
+
+
+async def test_step_reaches_inside_the_begin_block(tmp_path):
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        seen = []
+        for _ in range(12):
+            path, line, name = await _where(c)
+            seen.append((line, name))
+            if line == 5:  # `my $x = 10;` inside BEGIN
+                break
+            await c.request("stepIn", {"threadId": 1})
+            await c.wait_event("stopped", timeout=20)
+        assert any(line == 5 for line, _ in seen), f"never entered BEGIN: {seen}"
+        assert all(
+            "TdbCompile" not in str(p) for p in [prog]
+        )  # sanity; real check below
+    finally:
+        await c.stop()
+
+
+async def test_no_stop_is_reported_inside_tdbcompile_pm(tmp_path):
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        for _ in range(20):
+            path, _, _ = await _where(c)
+            assert "TdbCompile.pm" not in path, "leaked a stop inside tdb's own shim"
+            await c.request("stepIn", {"threadId": 1})
+            try:
+                await c.wait_event("stopped", timeout=15)
+            except AssertionError:
+                break
+    finally:
+        await c.stop()
+
+
+async def test_program_without_compile_time_statements_unchanged(tmp_path):
+    c, prog = await _launch(tmp_path, NO_PRAGMAS)
+    try:
+        path, line, _ = await _where(c)
+        assert (path, line) == (prog, 1)
+    finally:
+        await c.stop()
+
+
+async def test_breakpoints_set_during_compile_phase_still_fire(tmp_path):
+    """Regression for the partial-line-table hazard: a breakpoint requested
+    at the first (compile-phase) stop must fire once the program runs."""
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        await c.request(
+            "setBreakpoints",
+            {"source": {"path": prog}, "breakpoints": [{"line": 11}]},
+        )
+        await c.request("continue", {"threadId": 1})
+        await c.wait_event("stopped", timeout=30)
+        path, line, _ = await _where(c)
+        assert (path, line) == (prog, 11)
+    finally:
+        await c.stop()
+
+
+async def test_end_block_still_steppable(tmp_path):
+    """Background 5: END blocks already worked; must not regress."""
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        await c.request(
+            "setBreakpoints",
+            {"source": {"path": prog}, "breakpoints": [{"line": 11}]},
+        )
+        await c.request("continue", {"threadId": 1})
+        await c.wait_event("stopped", timeout=30)
+        seen = []
+        for _ in range(8):
+            await c.request("stepIn", {"threadId": 1})
+            try:
+                await c.wait_event("stopped", timeout=15)
+            except AssertionError:
+                break
+            _, line, name = await _where(c)
+            seen.append((line, name))
+        assert any("END" in str(name) for _, name in seen), f"END not reached: {seen}"
+    finally:
+        await c.stop()
+
+
+async def test_compile_phase_location_never_reports_unknown(tmp_path):
+    """Pins the task-4 kill hazard: _classify_and_emit_stop treats a
+    location() of file "?" as proof the debuggee ran to completion, and
+    (in launch mode) force-quits it with `q`. A compile-phase stop that
+    ever reported "?" would trip that branch and kill a debuggee that's
+    still very much alive. Drives Devel::TdbHelper::location() directly
+    (the same helper _classify_and_emit_stop calls), independent of the
+    DAP layer, through every stop from the first compile-time statement
+    into the BEGIN block.
+    """
+    prog = tmp_path / "p.pl"
+    prog.write_text(WITH_BEGIN)
+    outputs: list[tuple[str, str]] = []
+    session = PerlSession(
+        on_output=lambda text, cat: outputs.append((text, cat)),
+        on_stop=lambda: None,
+    )
+    await asyncio.wait_for(
+        session.launch(program=str(prog), args=[], cwd=str(tmp_path), env=None),
+        20.0,
+    )
+    try:
+        seen_files = []
+        for _ in range(9):
+            loc = await session.helper("Devel::TdbHelper::location()")
+            f = loc.get("file")
+            seen_files.append(f)
+            assert f not in (None, "", "?"), f"location() reported {f!r}: {seen_files}"
+            assert f == str(prog)
+            try:
+                await session.command("s")
+            except PerlProtocolError:
+                break
+    finally:
+        await session.stop()
+
+
+async def test_compile_phase_shim_does_not_exhaust_memory(tmp_path):
+    """Regression guard for the OOM bug fixed in TdbCompile.pm.
+
+    An earlier version of the shim kept its DB::DB wrapper installed
+    for the debuggee's whole life and made the RUN-phase branch a bare
+    `goto &$orig` pass-through. Verified empirically, that combination
+    reliably makes perl die with "Out of memory in
+    perl:util:safesysmalloc" once RUN-phase execution proceeds -- it
+    crashed the development machine's session twice. The fix
+    self-uninstalls the wrapper (`*DB::DB = $orig`) the moment
+    ${^GLOBAL_PHASE} leaves 'START', before the tail-call `goto`.
+
+    This drives the real shim through the compile phase and a genuine
+    `continue` to completion under an explicit, tight RLIMIT_AS
+    (independent of whatever ulimit the test runner itself happens to
+    be wrapped in) and asserts perl exits cleanly -- so a reintroduction
+    of the bug fails fast here instead of silently exhausting memory
+    again.
+    """
+    import resource
+
+    prog = tmp_path / "loopy.pl"
+    prog.write_text(
+        "use strict;\n"
+        "use warnings;\n"
+        "BEGIN { my $x = 1; }\n"
+        + "".join(f"my $v{i} = {i};\n" for i in range(200))
+        + 'print STDERR "done\\n";\n'
+    )
+
+    mem_limit = 300 * 1024 * 1024  # comfortably above a healthy perl
+    # process (a few MB); comfortably below anything that could risk
+    # the host if the leak regresses.
+
+    def _limit_memory() -> None:
+        resource.setrlimit(resource.RLIMIT_AS, (mem_limit, mem_limit))
+
+    connected: asyncio.Future = asyncio.get_running_loop().create_future()
+
+    async def _on_connect(reader, writer):
+        if not connected.done():
+            connected.set_result((reader, writer))
+
+    server = await asyncio.start_server(_on_connect, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    env = dict(os.environ)
+    env["PERLDB_OPTS"] = f"RemotePort=127.0.0.1:{port}"
+    env["TDB_COMPILE_FILE"] = str(prog)
+    adapters_dir = os.path.dirname(helpers_path())
+    proc = await asyncio.create_subprocess_exec(
+        "perl",
+        "-d",
+        f"-I{adapters_dir}",
+        "-MDevel::TdbCompile",
+        str(prog),
+        cwd=str(tmp_path),
+        env=env,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        preexec_fn=_limit_memory,
+    )
+    stderr_chunks: list[bytes] = []
+
+    async def _pump_stderr() -> None:
+        while True:
+            chunk = await proc.stderr.read(4096)
+            if not chunk:
+                return
+            stderr_chunks.append(chunk)
+
+    async def _drain_stdout() -> None:
+        while True:
+            chunk = await proc.stdout.read(4096)
+            if not chunk:
+                return
+
+    stderr_task = asyncio.ensure_future(_pump_stderr())
+    stdout_task = asyncio.ensure_future(_drain_stdout())
+    try:
+        reader, writer = await asyncio.wait_for(connected, 10.0)
+        server.close()
+
+        async def _next_prompt_text() -> str:
+            parser = StreamParser()
+            parts: list[str] = []
+            while True:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    return "".join(parts)
+                for ev in parser.feed(chunk):
+                    if ev[0] == "text":
+                        parts.append(ev[1])
+                    elif ev[0] == "prompt":
+                        return "".join(parts)
+
+        await asyncio.wait_for(_next_prompt_text(), 10.0)  # first compile-phase stop
+        # `continue` runs the program to completion. The shim's own
+        # self-uninstall leaks exactly one extra stop, inside
+        # TdbCompile.pm itself, at the START->RUN transition (the same
+        # leak server.py's _location_after_settling steps past for real
+        # sessions) -- drive through it the same way, then perl5db's
+        # inhibit_exit (on by default) parks the still-alive child at a
+        # fresh prompt instead of exiting, so a final `q` is needed to
+        # make it really exit.
+        text = ""
+        for _ in range(5):
+            writer.write(b"c\n")
+            await writer.drain()
+            text = await asyncio.wait_for(_next_prompt_text(), 15.0)
+            if "TdbCompile.pm" not in text:
+                break
+        assert "TdbCompile.pm" not in text, f"stop leaked into the shim: {text!r}"
+        writer.write(b"q\n")
+        await writer.drain()
+        try:
+            await asyncio.wait_for(proc.wait(), 15.0)
+        except asyncio.TimeoutError:
+            pass
+        await asyncio.wait_for(asyncio.gather(stderr_task, stdout_task), 5.0)
+        stderr = b"".join(stderr_chunks)
+        assert proc.returncode == 0, (
+            f"perl died (rc={proc.returncode}); "
+            f"stderr={stderr.decode(errors='replace')!r}"
+        )
+        assert b"Out of memory" not in stderr
+        assert b"done" in stderr
+    finally:
+        stderr_task.cancel()
+        stdout_task.cancel()
+        if proc.returncode is None:
+            proc.kill()
+            await proc.wait()
+        server.close()

--- a/tests/integration/test_perl_begin_blocks.py
+++ b/tests/integration/test_perl_begin_blocks.py
@@ -191,6 +191,10 @@ async def test_compile_phase_location_never_reports_unknown(tmp_path):
         await session.stop()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="resource.RLIMIT_AS / preexec_fn are POSIX-only (no Windows equivalent)",
+)
 async def test_compile_phase_shim_does_not_exhaust_memory(tmp_path):
     """Regression guard for the OOM bug fixed in TdbCompile.pm.
 

--- a/tests/integration/test_perl_begin_blocks.py
+++ b/tests/integration/test_perl_begin_blocks.py
@@ -154,6 +154,127 @@ async def test_end_block_still_steppable(tmp_path):
         await c.stop()
 
 
+async def test_breakpoint_inside_begin_block_fires(tmp_path):
+    """The bug this file exists to fix: a breakpoint on a statement
+    inside a BEGIN block must actually stop there (not be silently
+    skipped, and not merely apply once RUN phase arrives -- by then the
+    BEGIN block has already finished executing)."""
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        resp = await c.request(
+            "setBreakpoints",
+            {"source": {"path": prog}, "breakpoints": [{"line": 5}]},
+        )
+        (bp,) = resp["body"]["breakpoints"]
+        assert bp["verified"] is False  # deferred: still compiling
+        await c.request("continue", {"threadId": 1})
+        stopped = await c.wait_event("stopped", timeout=30)
+        assert stopped["body"]["reason"] == "breakpoint"
+        path, line, name = await _where(c)
+        assert (path, line) == (prog, 5)
+        assert name == "main::BEGIN"
+    finally:
+        await c.stop()
+
+
+async def test_conditional_breakpoint_inside_begin_fires_when_true(tmp_path):
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        await c.request(
+            "setBreakpoints",
+            {
+                "source": {"path": prog},
+                "breakpoints": [{"line": 6, "condition": "$x == 10"}],
+            },
+        )
+        await c.request("continue", {"threadId": 1})
+        stopped = await c.wait_event("stopped", timeout=30)
+        assert stopped["body"]["reason"] == "breakpoint"
+        path, line, name = await _where(c)
+        assert (path, line) == (prog, 6)
+        assert name == "main::BEGIN"
+    finally:
+        await c.stop()
+
+
+async def test_conditional_breakpoint_inside_begin_skipped_when_false(tmp_path):
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        await c.request(
+            "setBreakpoints",
+            {
+                "source": {"path": prog},
+                "breakpoints": [{"line": 6, "condition": "$x == 99"}],
+            },
+        )
+        await c.request("continue", {"threadId": 1})
+        # Condition never true: no compile-phase stop, no runtime
+        # breakpoint left behind either -- runs to completion.
+        await c.wait_event("terminated", timeout=30)
+    finally:
+        await c.stop()
+
+
+async def test_begin_breakpoint_does_not_refire_on_next_continue(tmp_path):
+    """Regression: after the compile-phase breakpoint fires, a further
+    `continue` must proceed past it (never re-fire on the same line)."""
+    c, prog = await _launch(tmp_path, WITH_BEGIN)
+    try:
+        await c.request(
+            "setBreakpoints",
+            {"source": {"path": prog}, "breakpoints": [{"line": 5}, {"line": 10}]},
+        )
+        await c.request("continue", {"threadId": 1})
+        stopped = await c.wait_event("stopped", timeout=30)
+        assert stopped["body"]["reason"] == "breakpoint"
+        path, line, _ = await _where(c)
+        assert (path, line) == (prog, 5)
+
+        await c.request("continue", {"threadId": 1})
+        stopped2 = await c.wait_event("stopped", timeout=30)
+        assert stopped2["body"]["reason"] == "breakpoint"
+        path2, line2, _ = await _where(c)
+        assert (path2, line2) == (prog, 10), "re-fired on the same BEGIN line"
+    finally:
+        await c.stop()
+
+
+RUNTIME_LINE_BEFORE_LATER_BEGIN = """use strict;
+use warnings;
+
+my $b = 20;
+print STDERR "before begin $b\\n";
+
+BEGIN {
+    my $x = 1;
+}
+
+print STDERR "after begin\\n";
+"""
+
+
+async def test_runtime_breakpoint_not_falsely_fired_by_later_begin_block(tmp_path):
+    """Regression: a breakpoint on a RUNTIME line must fire at that exact
+    runtime line, not during the compile phase merely because a
+    compile-time statement (the BEGIN block) appears later in the file.
+    Snap-forward matching would get this wrong; exact line equality
+    must not."""
+    c, prog = await _launch(tmp_path, RUNTIME_LINE_BEFORE_LATER_BEGIN, name="q.pl")
+    try:
+        await c.request(
+            "setBreakpoints",
+            {"source": {"path": prog}, "breakpoints": [{"line": 4}]},
+        )
+        await c.request("continue", {"threadId": 1})
+        stopped = await c.wait_event("stopped", timeout=30)
+        assert stopped["body"]["reason"] == "breakpoint"
+        path, line, name = await _where(c)
+        assert (path, line) == (prog, 4)
+        assert name != "main::BEGIN"
+    finally:
+        await c.stop()
+
+
 async def test_compile_phase_location_never_reports_unknown(tmp_path):
     """Pins the task-4 kill hazard: _classify_and_emit_stop treats a
     location() of file "?" as proof the debuggee ran to completion, and

--- a/tests/integration/test_perl_exit_code.py
+++ b/tests/integration/test_perl_exit_code.py
@@ -1,0 +1,41 @@
+"""A perl program that dies must not report exitCode 0."""
+
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, "tests/integration")
+from perl_adapter_harness import AdapterClient
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("perl") is None
+    or subprocess.run(["perl", "-e", "require v5.18"]).returncode != 0,
+    reason="perl >= 5.18 required",
+)
+
+
+async def _run_to_exit(tmp_path, source):
+    prog = tmp_path / "p.pl"
+    prog.write_text(source)
+    c = AdapterClient()
+    await c.start()
+    await c.request("initialize", {})
+    c.send("launch", {"program": str(prog), "cwd": str(tmp_path)})
+    await c.wait_event("initialized")
+    await c.request("configurationDone", {})
+    await c.wait_event("stopped")
+    await c.request("continue", {"threadId": 1})
+    ev = await c.wait_event("exited", timeout=30)
+    await c.stop()
+    return ev["body"]["exitCode"]
+
+
+async def test_clean_exit_reports_zero(tmp_path):
+    assert await _run_to_exit(tmp_path, 'print "ok\\n";\n') == 0
+
+
+async def test_die_reports_nonzero(tmp_path):
+    code = await _run_to_exit(tmp_path, "my $x = 0;\nmy $y = 1 / $x;\n")
+    assert code != 0

--- a/tests/integration/test_perl_session_driver.py
+++ b/tests/integration/test_perl_session_driver.py
@@ -17,6 +17,25 @@ pytestmark = pytest.mark.skipif(
 
 WAIT = 20.0
 
+
+async def _settle_to_run_phase(s: PerlSession) -> None:
+    """Step a session that may still be inside perl's compile phase
+    (Task 5 / Background 8) forward to the START->RUN transition.
+
+    Mirrors server.py's own `_settle_to_run_phase`, at the raw-session
+    level these tests operate at: while phase is 'START' the target
+    file may be only partially compiled, so `b file:line` on a
+    not-yet-parsed line answers "not breakable" and source()/
+    breakable() see a partial line table. Bounded the same way the
+    product code is, so a pathological compile phase can't hang a test.
+    """
+    for _ in range(1000):
+        phase = await s.helper("Devel::TdbHelper::phase()")
+        if phase["phase"] != "START":
+            return
+        await s.command("n")
+
+
 SCRIPT = """\
 my $x = 1;
 my $y = 2;
@@ -66,7 +85,14 @@ async def test_launch_stops_at_entry_with_helpers_injected(session, script):
 
 async def test_breakpoint_continue_and_unsolicited_stop(session, script):
     s, _, stops = session
-    events = await s.command(f"b 4")
+    # File-qualified: a bare `b 4` targets perl5db's own notion of the
+    # "current file" for unqualified breakpoint commands, which -- now
+    # that Devel::TdbCompile (this adapter's compile-phase shim, always
+    # loaded in launch mode) is a second file in the process -- is no
+    # longer reliably `script` even once execution is back in it. The
+    # real adapter (server.py) never issues a bare `b LINE` for exactly
+    # this reason; it always qualifies with the file.
+    events = await s.command(f"b {script}:4")
     assert not any(e[0] == "json" for e in events)
     s.resume("c")
     for _ in range(200):
@@ -88,12 +114,14 @@ async def test_program_output_reaches_callback(session):
     assert any("z=3" in t for t, c in outputs if c == "stdout")
 
 
-async def test_perl5db_chatter_not_forwarded_as_output(session):
+async def test_perl5db_chatter_not_forwarded_as_output(session, script):
     """perl5db echoes the current source line at every stop
     (`main::(file:line): code`). That is debugger chatter, not program
     output -- it must never surface through on_output."""
     s, outputs, stops = session
-    await s.command("b 4")
+    # File-qualified for the same reason as test_breakpoint_continue_
+    # and_unsolicited_stop above -- see that test's comment.
+    await s.command(f"b {script}:4")
     s.resume("c")
     for _ in range(200):
         if stops:
@@ -279,6 +307,16 @@ async def test_source_of_large_file_with_angle_brackets_round_trips(
         WAIT,
     )
     try:
+        # `program` opens with `use strict;`/`use warnings;`, so (Task 5)
+        # launch() now stops there mid-compile-phase, with only the file
+        # parsed so far in perl5db's line table -- source() legitimately
+        # returns a partial file at that point (see helpers.pl's own
+        # breakable()/source() comments and Background 8 in the plan).
+        # Settle to the RUN-phase transition, the same way server.py's
+        # _settle_to_run_phase does, before asserting the full text
+        # round-trips -- this test is about the marker-splitting bug,
+        # not about compile-phase partial compilation.
+        await _settle_to_run_phase(s)
         payload = await s.helper(f"Devel::TdbHelper::source({program!r})")
         assert payload["text"] == expected_text
     finally:
@@ -297,8 +335,19 @@ async def test_breakable_populates_and_breakpoint_lands_after_require(
         s.launch(program=main, args=[], cwd=str(tmp_path_of(main)), env=None), WAIT
     )
     try:
+        # main.pl opens with `use strict; use warnings;` (line 1), a
+        # compile-time statement, so (Task 5) the entry stop lands
+        # there mid-compile-phase, with the rest of the file not yet
+        # parsed -- `b main:3` would answer "not breakable" (Background
+        # 8) if issued now. Settle past the compile phase first, the
+        # same way server.py defers real breakpoint application until
+        # phase() reports RUN.
+        await _settle_to_run_phase(s)
         # Stop right after the require (main.pl line 3 is the call site).
-        await s.command("b 3")
+        # File-qualified -- see test_breakpoint_continue_and_unsolicited_
+        # stop's comment: a bare `b LINE` no longer reliably targets
+        # `main` now that Devel::TdbCompile is always loaded alongside it.
+        await s.command(f"b {main}:3")
         s.resume("c")
         for _ in range(200):
             if stops:

--- a/tests/unit/test_controller_actions.py
+++ b/tests/unit/test_controller_actions.py
@@ -20,6 +20,7 @@ from tdb.session.controller import DebugController
 from tdb.session.event_bus import DebugEventHandler
 from tdb.session.state import SessionPhase
 from tdb.dap.types import (
+    DEFERRED_VERIFICATION_MESSAGE,
     Breakpoint,
     Capabilities,
     Scope,
@@ -432,6 +433,92 @@ async def test_partially_bound_breakpoints_do_not_warn():
         {"verified": False, "line": 5},
     ]
     await ctrl.set_breakpoint_condition("/f.py", 3, "x > 1")
+    assert not [o for o in handler.outputs if "debug info" in o[0]]
+
+
+async def test_deferred_breakpoints_do_not_warn():
+    """Requirement 5 / final-review Important #2: a setBreakpoints answer
+    carrying DEFERRED_VERIFICATION_MESSAGE (perl's compile-phase
+    deferral) means "verification postponed", not "no debug info" —
+    the missing-debug-info guess-warning must stay silent for it."""
+    ctrl, fake, handler = _make()
+    fake.breakpoint_results = [
+        {"verified": False, "line": 3, "message": DEFERRED_VERIFICATION_MESSAGE}
+    ]
+    await ctrl.add_breakpoint("/x/prog.pl", 3)
+    assert not [o for o in handler.outputs if "debug info" in o[0]]
+
+
+async def test_breakpoint_changed_event_updates_verified_state():
+    """The adapter's `breakpoint` "changed" event (sent when a deferred
+    perl breakpoint is finally applied for real) must correct the
+    stored verified flag — this is plan requirement 5's UI half,
+    previously unimplemented (final-review Important #2)."""
+    ctrl, fake, handler = _make()
+    ctrl.state.breakpoints["/x/prog.pl"] = [SourceBreakpoint(line=3, verified=False)]
+    ctrl._on_breakpoint_event(
+        Event(
+            seq=1,
+            event="breakpoint",
+            body={
+                "reason": "changed",
+                "breakpoint": {
+                    "verified": True,
+                    "line": 3,
+                    "source": {"path": "/x/prog.pl"},
+                },
+            },
+        )
+    )
+    (bp,) = ctrl.state.breakpoints["/x/prog.pl"]
+    assert bp.verified is True
+    assert not [o for o in handler.outputs if "debug info" in o[0]]
+
+
+async def test_breakpoint_changed_event_warns_when_genuinely_unbound():
+    """Once the deferred breakpoint is actually resolved (no more
+    DEFERRED_VERIFICATION_MESSAGE excuse), a real all-unverified
+    outcome should still surface the missing-debug-info hint."""
+    ctrl, fake, handler = _make()
+    ctrl.state.breakpoints["/x/prog.pl"] = [SourceBreakpoint(line=3, verified=False)]
+    ctrl._on_breakpoint_event(
+        Event(
+            seq=1,
+            event="breakpoint",
+            body={
+                "reason": "changed",
+                "breakpoint": {
+                    "verified": False,
+                    "line": 3,
+                    "source": {"path": "/x/prog.pl"},
+                },
+            },
+        )
+    )
+    (bp,) = ctrl.state.breakpoints["/x/prog.pl"]
+    assert bp.verified is False
+    assert [o for o in handler.outputs if "debug info" in o[0]]
+
+
+async def test_breakpoint_changed_event_ignores_unknown_line():
+    ctrl, fake, handler = _make()
+    ctrl.state.breakpoints["/x/prog.pl"] = [SourceBreakpoint(line=3, verified=False)]
+    ctrl._on_breakpoint_event(
+        Event(
+            seq=1,
+            event="breakpoint",
+            body={
+                "reason": "changed",
+                "breakpoint": {
+                    "verified": True,
+                    "line": 99,
+                    "source": {"path": "/x/prog.pl"},
+                },
+            },
+        )
+    )
+    (bp,) = ctrl.state.breakpoints["/x/prog.pl"]
+    assert bp.verified is False  # untouched — no matching line
     assert not [o for o in handler.outputs if "debug info" in o[0]]
 
 

--- a/tests/unit/test_dap_event_coordinator.py
+++ b/tests/unit/test_dap_event_coordinator.py
@@ -141,6 +141,45 @@ def test_check_stderr_traceback_parses_simple_tb():
     assert top.name == "main"
 
 
+# --- exit-code gate threading (Task 4) ----------------------------------
+
+
+def _perl_coord() -> tuple[DapEventCoordinator, _StubApp]:
+    from tdb.languages import registry
+
+    co, app = _coord()
+    app.controller.profile = registry.resolve("perl")
+    return co, app
+
+
+def test_check_stderr_traceback_perl_unlisted_warning_clean_exit_no_modal():
+    co, app = _perl_coord()
+    app._stderr_buffer = ['Deep recursion on subroutine "main::f" at /w/x.pl line 3.\n']
+    co._check_stderr_traceback(exit_code=0)
+    assert app.pushed_screens == []
+
+
+def test_check_stderr_traceback_perl_unlisted_warning_nonzero_exit_shows_modal():
+    co, app = _perl_coord()
+    app._stderr_buffer = ['Deep recursion on subroutine "main::f" at /w/x.pl line 3.\n']
+    co._check_stderr_traceback(exit_code=255)
+    assert len(app.pushed_screens) == 1
+
+
+async def test_wait_for_exit_code_returns_immediately_when_already_set():
+    co, app = _coord()
+    app.controller.state.last_exit_code = 5
+    result = await co._wait_for_exit_code(max_wait=5.0)
+    assert result == 5
+
+
+async def test_wait_for_exit_code_falls_back_to_none_after_bound():
+    co, app = _coord()
+    assert app.controller.state.last_exit_code is None
+    result = await co._wait_for_exit_code(max_wait=0.05)
+    assert result is None
+
+
 def test_check_stderr_traceback_chained_uses_final_block_for_frames():
     """When multiple traceback blocks chain, synthetic frames come from
     the LAST block (the exception that actually killed the program)."""

--- a/tests/unit/test_dap_event_coordinator.py
+++ b/tests/unit/test_dap_event_coordinator.py
@@ -166,6 +166,21 @@ def test_check_stderr_traceback_perl_unlisted_warning_nonzero_exit_shows_modal()
     assert len(app.pushed_screens) == 1
 
 
+def test_check_stderr_traceback_perl_innermost_frame_uses_main_not_module():
+    """Final-review Minor #5: perl's innermost error frame always has
+    func="" (top-level/BEGIN code, no named sub -- see
+    languages/errors.py's parse_perl_error), and must not borrow
+    Python's "<module>" placeholder for it. It should match perl's own
+    live stackTrace convention instead (adapters/perl/server.py's
+    `f.get("sub") or "main"`)."""
+    co, app = _perl_coord()
+    app._stderr_buffer = ["Illegal division by zero at /w/x.pl line 10.\n"]
+    co._check_stderr_traceback(exit_code=255)
+    assert app.controller.state.stack_frames
+    top = app.controller.state.stack_frames[0]
+    assert top.name == "main"
+
+
 async def test_wait_for_exit_code_returns_immediately_when_already_set():
     co, app = _coord()
     app.controller.state.last_exit_code = 5

--- a/tests/unit/test_error_modal_routing.py
+++ b/tests/unit/test_error_modal_routing.py
@@ -13,6 +13,19 @@ ZeroDivisionError: division by zero
 
 PERL_DIE = "Illegal division by zero at /w/x.pl line 4.\n"
 
+CHAINED_PY_TB = """Traceback (most recent call last):
+  File "/app/a.py", line 2, in <module>
+    inner()
+ValueError: first
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/app/b.py", line 9, in <module>
+    outer()
+RuntimeError: second
+"""
+
 
 async def _pushed_modal(app, stderr_text):
     pushed = []
@@ -45,6 +58,26 @@ async def test_perl_die_shows_modal_with_frames():
         # Code View / stack navigated to the failing frame
         assert app.controller.state.stack_frames
         assert app.controller.state.stack_frames[0].line == 4
+
+
+async def test_chained_python_traceback_modal_body_keeps_raw_detail():
+    """The modal body for Python must not lose information relative to
+    the pre-refactor inline implementation: source-snippet lines
+    (e.g. "    outer()") and the chained-exception separator sentence
+    ("The above exception was the direct cause...") must both still be
+    present in the cached/displayed frames text, not just the
+    structured File/line/func summary."""
+    app = TdbApp(program="", config=TdbConfig())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pushed = await _pushed_modal(app, CHAINED_PY_TB)
+        assert pushed, "chained python traceback should push a modal"
+        body = app.panels.last_frames_text
+        assert "    outer()" in body
+        assert (
+            "The above exception was the direct cause of the following exception:"
+            in body
+        )
 
 
 async def test_non_error_stderr_shows_nothing():

--- a/tests/unit/test_error_modal_routing.py
+++ b/tests/unit/test_error_modal_routing.py
@@ -1,0 +1,57 @@
+"""The stderr error modal is driven by the active language profile."""
+
+import pytest
+
+from tdb.app import TdbApp
+from tdb.persist import TdbConfig
+
+PY_TB = """Traceback (most recent call last):
+  File "/app/main.py", line 3, in <module>
+    boom()
+ZeroDivisionError: division by zero
+"""
+
+PERL_DIE = "Illegal division by zero at /w/x.pl line 4.\n"
+
+
+async def _pushed_modal(app, stderr_text):
+    pushed = []
+    app.push_screen = lambda screen, callback=None: pushed.append(screen)
+    app._stderr_buffer.clear()
+    app._stderr_buffer.append(stderr_text)
+    app._dap._check_stderr_traceback()
+    return pushed
+
+
+async def test_python_traceback_still_shows_modal():
+    app = TdbApp(program="", config=TdbConfig())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pushed = await _pushed_modal(app, PY_TB)
+        assert pushed, "python traceback should push a modal"
+        assert "ZeroDivisionError" in app.panels.last_exception_text
+
+
+async def test_perl_die_shows_modal_with_frames():
+    from tdb.languages import registry
+
+    app = TdbApp(program="", config=TdbConfig(), profile=registry.resolve("perl"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pushed = await _pushed_modal(app, PERL_DIE)
+        assert pushed, "perl die should push a modal"
+        assert "Illegal division by zero" in app.panels.last_exception_text
+        assert "/w/x.pl" in app.panels.last_frames_text
+        # Code View / stack navigated to the failing frame
+        assert app.controller.state.stack_frames
+        assert app.controller.state.stack_frames[0].line == 4
+
+
+async def test_non_error_stderr_shows_nothing():
+    from tdb.languages import registry
+
+    app = TdbApp(program="", config=TdbConfig(), profile=registry.resolve("perl"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pushed = await _pushed_modal(app, "just a log line\n")
+        assert pushed == []

--- a/tests/unit/test_error_parsers.py
+++ b/tests/unit/test_error_parsers.py
@@ -1,0 +1,60 @@
+"""Language-specific fatal-error parsers behind Presentation.parse_error."""
+
+from tdb.languages.errors import parse_python_error
+
+SIMPLE = """Traceback (most recent call last):
+  File "/app/main.py", line 12, in <module>
+    boom()
+  File "/app/lib.py", line 5, in boom
+    return 1 / 0
+ZeroDivisionError: division by zero
+"""
+
+CHAINED = """Traceback (most recent call last):
+  File "/app/a.py", line 2, in <module>
+    inner()
+ValueError: first
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File "/app/b.py", line 9, in <module>
+    outer()
+RuntimeError: second
+"""
+
+
+def test_returns_none_without_traceback():
+    assert parse_python_error("just some stderr noise\n") is None
+
+
+def test_parses_message_and_frames_in_source_order():
+    p = parse_python_error(SIMPLE)
+    assert p is not None
+    assert p.header == "Traceback (most recent call last):"
+    assert p.message == "ZeroDivisionError: division by zero"
+    assert [(f.path, f.line, f.func) for f in p.frames] == [
+        ("/app/main.py", 12, "<module>"),
+        ("/app/lib.py", 5, "boom"),
+    ]
+
+
+def test_chained_traceback_uses_last_block():
+    p = parse_python_error(CHAINED)
+    assert p is not None
+    assert p.message == "RuntimeError: second"
+    assert [f.path for f in p.frames] == ["/app/b.py"]
+
+
+def test_presentation_exposes_parser_for_python():
+    from tdb.languages import registry
+
+    profile = registry.resolve("python")
+    assert profile.presentation.parse_error is not None
+    assert profile.presentation.parse_error(SIMPLE) is not None
+
+
+def test_presentation_parse_error_defaults_to_none():
+    from tdb.languages.base import Presentation
+
+    assert Presentation().parse_error is None

--- a/tests/unit/test_error_parsers.py
+++ b/tests/unit/test_error_parsers.py
@@ -58,3 +58,65 @@ def test_presentation_parse_error_defaults_to_none():
     from tdb.languages.base import Presentation
 
     assert Presentation().parse_error is None
+
+
+from tdb.languages.errors import parse_perl_error
+
+PERL_COMPILE = """Illegal division by zero at /w/has_begin.pl line 10.
+ at /w/has_begin.pl line 10.
+\tmain::BEGIN() called at /w/has_begin.pl line 11
+\teval {...} called at /w/has_begin.pl line 11
+BEGIN failed--compilation aborted at /w/has_begin.pl line 11.
+"""
+
+PERL_RUNTIME = "Illegal division by zero at /tmp/x.pl line 4.\n"
+
+PERL_DIE_IN_SUB = """boom at /tmp/x.pl line 3.
+\tmain::inner() called at /tmp/x.pl line 7
+\tmain::outer() called at /tmp/x.pl line 10
+"""
+
+
+def test_perl_returns_none_for_plain_output():
+    assert parse_perl_error("hello world\n") is None
+
+
+def test_perl_runtime_die_message_and_frame():
+    p = parse_perl_error(PERL_RUNTIME)
+    assert p is not None
+    assert p.header == "Perl error:"
+    assert p.message == "Illegal division by zero"
+    assert [(f.path, f.line) for f in p.frames] == [("/tmp/x.pl", 4)]
+
+
+def test_perl_compile_abort_frames_skip_eval_scaffolding():
+    p = parse_perl_error(PERL_COMPILE)
+    assert p is not None
+    assert p.message == "Illegal division by zero"
+    assert [(f.path, f.line, f.func) for f in p.frames] == [
+        ("/w/has_begin.pl", 11, "main::BEGIN"),
+        ("/w/has_begin.pl", 10, ""),
+    ]
+
+
+def test_perl_nested_call_frames_outermost_first():
+    p = parse_perl_error(PERL_DIE_IN_SUB)
+    assert p is not None
+    assert [(f.line, f.func) for f in p.frames] == [
+        (10, "main::outer"),
+        (7, "main::inner"),
+        (3, ""),
+    ]
+
+
+def test_perl_warning_alone_is_not_fatal():
+    warn = "Use of uninitialized value in division (/) at /w/x.pl line 10.\n"
+    assert parse_perl_error(warn) is None
+
+
+def test_presentation_exposes_parser_for_perl():
+    from tdb.languages import registry
+
+    profile = registry.resolve("perl")
+    assert profile.presentation.parse_error is not None
+    assert profile.presentation.parse_error(PERL_RUNTIME) is not None

--- a/tests/unit/test_error_parsers.py
+++ b/tests/unit/test_error_parsers.py
@@ -46,6 +46,16 @@ def test_chained_traceback_uses_last_block():
     assert [f.path for f in p.frames] == ["/app/b.py"]
 
 
+def test_python_error_ignores_exit_code():
+    # A caught traceback (traceback.print_exc()) can print alongside a
+    # clean exit(0) -- gating on exit code would be a regression, so the
+    # python parser must return the identical result regardless of it.
+    assert parse_python_error(SIMPLE, exit_code=0) == parse_python_error(
+        SIMPLE, exit_code=None
+    )
+    assert parse_python_error(SIMPLE, exit_code=0) is not None
+
+
 def test_presentation_exposes_parser_for_python():
     from tdb.languages import registry
 
@@ -112,6 +122,41 @@ def test_perl_nested_call_frames_outermost_first():
 def test_perl_warning_alone_is_not_fatal():
     warn = "Use of uninitialized value in division (/) at /w/x.pl line 10.\n"
     assert parse_perl_error(warn) is None
+
+
+# --- exit-code gate (Task 4) ---------------------------------------------
+# Replaces the fragile prefix denylist: a warning opener NOT on
+# _PERL_WARNING_PREFIXES (e.g. "Deep recursion on subroutine") used to be
+# misclassified as fatal. With a real exit code available, fatality is
+# exactly `exit_code != 0` regardless of the message's wording.
+
+UNLISTED_WARNING = 'Deep recursion on subroutine "main::f" at /w/x.pl line 3.\n'
+
+
+def test_perl_gate_unlisted_warning_with_clean_exit_is_not_fatal():
+    # Not on the old denylist -- would have been misclassified as fatal
+    # before the exit-code gate.
+    assert parse_perl_error(UNLISTED_WARNING, exit_code=0) is None
+
+
+def test_perl_gate_unlisted_warning_with_nonzero_exit_is_fatal():
+    p = parse_perl_error(UNLISTED_WARNING, exit_code=255)
+    assert p is not None
+    assert p.message == 'Deep recursion on subroutine "main::f"'
+
+
+def test_perl_gate_real_die_with_none_exit_code_uses_shape_fallback():
+    # exit_code=None (attach mode, or the `exited` DAP event hasn't arrived
+    # yet): falls back to the old shape-based heuristic, which still
+    # correctly classifies a genuine die as fatal.
+    p = parse_perl_error(PERL_RUNTIME, exit_code=None)
+    assert p is not None
+    assert p.message == "Illegal division by zero"
+
+
+def test_perl_gate_listed_warning_with_none_exit_code_uses_shape_fallback():
+    warn = "Use of uninitialized value in division (/) at /w/x.pl line 10.\n"
+    assert parse_perl_error(warn, exit_code=None) is None
 
 
 def test_presentation_exposes_parser_for_perl():

--- a/tests/unit/test_perl_dap_server.py
+++ b/tests/unit/test_perl_dap_server.py
@@ -295,6 +295,7 @@ async def test_on_unsolicited_stop_keeps_strong_reference_to_classify_task():
 
     class StubSession:
         stopped = True
+        pid = None  # attach-like: "?" branch must not try to send `q`
 
         async def helper(self, expr, timeout=20.0):
             return {"file": "?", "line": 1}
@@ -304,6 +305,134 @@ async def test_on_unsolicited_stop_keeps_strong_reference_to_classify_task():
 
     assert server._classify_task is not None
     assert not server._classify_task.done()
+
+
+async def test_ended_location_in_launch_mode_sends_q_and_reports_real_exit_code():
+    """launch mode (owned child, `pid` set): the "?" branch must force a
+    real exit via `q` and report the resulting code, not hardcode 0."""
+
+    class StubSession:
+        stopped = True
+        pid = 4242
+
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+
+        async def helper(self, expr, timeout=20.0):
+            return {"file": "?", "line": 0}
+
+        async def command(self, text, timeout=20.0):
+            self.commands.append(text)
+            raise PerlProtocolError("perl5db connection closed")
+
+        async def wait_exit_code(self) -> int:
+            return 7
+
+    reader = asyncio.StreamReader()
+    writer = SinkWriter()
+    server = PerlDapServer(reader, writer)
+    stub = StubSession()
+    server.session = stub
+    server._on_unsolicited_stop()
+    await server._classify_task
+
+    assert stub.commands == ["q"]
+    out = _messages(writer)
+    exited = [m for m in out if m.get("event") == "exited"][0]
+    assert exited["body"]["exitCode"] == 7
+    assert any(m.get("event") == "terminated" for m in out)
+    # Exactly one terminated/exited pair -- no duplicate from the `q`-
+    # triggered EOF this scenario simulates being guarded against.
+    assert len([m for m in out if m.get("event") == "terminated"]) == 1
+    assert len([m for m in out if m.get("event") == "exited"]) == 1
+
+
+async def test_ended_location_in_launch_mode_dedupes_against_forwarded_eof():
+    """The `q` sent by the "?" branch closes the socket, which in the real
+    adapter also drives `_forward_output("__eof__")` via the read loop.
+    _eof_terminated must make that a no-op instead of a second
+    terminated/exited pair."""
+
+    class StubSession:
+        stopped = True
+        pid = 4242
+
+        async def helper(self, expr, timeout=20.0):
+            return {"file": "?", "line": 0}
+
+        async def command(self, text, timeout=20.0):
+            raise PerlProtocolError("perl5db connection closed")
+
+        async def wait_exit_code(self) -> int:
+            return 3
+
+    reader = asyncio.StreamReader()
+    writer = SinkWriter()
+    server = PerlDapServer(reader, writer)
+    server.session = StubSession()
+    server._on_unsolicited_stop()
+    await server._classify_task
+    # Simulate the read loop observing the socket close the `q` caused.
+    server._forward_output("", "__eof__")
+
+    out = _messages(writer)
+    assert len([m for m in out if m.get("event") == "terminated"]) == 1
+    assert len([m for m in out if m.get("event") == "exited"]) == 1
+    assert server._eof_terminated is False  # consumed, ready for next time
+
+
+async def test_ended_location_in_attach_mode_reports_zero_without_sending_q():
+    """attach mode (no owned child, `pid` is None): must never send `q`
+    (that would kill the user's live remote process) and always reports 0,
+    matching the pre-existing attach contract."""
+
+    class StubSession:
+        stopped = True
+        pid = None
+
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+
+        async def helper(self, expr, timeout=20.0):
+            return {"file": "?", "line": 0}
+
+        async def command(self, text, timeout=20.0):
+            self.commands.append(text)
+            raise AssertionError("attach mode must never send a command here")
+
+    reader = asyncio.StreamReader()
+    writer = SinkWriter()
+    server = PerlDapServer(reader, writer)
+    stub = StubSession()
+    server.session = stub
+    server._on_unsolicited_stop()
+    await server._classify_task
+
+    assert stub.commands == []
+    out = _messages(writer)
+    exited = [m for m in out if m.get("event") == "exited"][0]
+    assert exited["body"]["exitCode"] == 0
+
+
+async def test_eof_without_prior_q_reports_real_exit_code():
+    """A genuinely unsolicited socket close (e.g. the debuggee hard-
+    crashed) must still report the child's real exit code, not 0."""
+
+    class StubSession:
+        async def wait_exit_code(self) -> int:
+            return 42
+
+    reader = asyncio.StreamReader()
+    writer = SinkWriter()
+    server = PerlDapServer(reader, writer)
+    server.session = StubSession()
+    server._forward_output("", "__eof__")
+    await server._eof_task
+
+    out = _messages(writer)
+    exited = [m for m in out if m.get("event") == "exited"][0]
+    assert exited["body"]["exitCode"] == 42
+    assert any(m.get("event") == "terminated" for m in out)
 
 
 async def test_pause_does_not_arm_flag_when_stop_wins_race():

--- a/tests/unit/test_perl_dap_server.py
+++ b/tests/unit/test_perl_dap_server.py
@@ -197,6 +197,58 @@ async def test_setBreakpoints_translates_to_remote_and_keys_by_remote_path():
     assert server.breakpoint_lines == {"/srv/app/x.pl": {10}}
 
 
+async def test_setBreakpoints_defers_during_compile_phase():
+    """Background 8 / requirement 5: a setBreakpoints request that
+    arrives while the debuggee is still compiling (phase START) must
+    defer -- never call b/breakable() on a partially-compiled file --
+    and answer verified:false with DEFERRED_VERIFICATION_MESSAGE so
+    controller.py's _warn_unbound_breakpoints knows this is a deferral,
+    not a genuine bind failure (see final-review Important #2)."""
+
+    class StubSession:
+        def __init__(self) -> None:
+            self.stopped = True
+            self.commands: list[str] = []
+
+        async def command(self, text, timeout=20.0):
+            self.commands.append(text)
+            return []
+
+        async def helper(self, expr, timeout=20.0):
+            assert "phase()" in expr
+            return {"phase": "START"}
+
+    reader = asyncio.StreamReader()
+    writer = SinkWriter()
+    server = PerlDapServer(reader, writer)
+    stub = StubSession()
+    server.session = stub
+
+    request = Request(
+        seq=1,
+        command="setBreakpoints",
+        arguments={
+            "source": {"path": "/local/src/x.pl"},
+            "breakpoints": [{"line": 10}],
+        },
+    )
+    await server._on_setBreakpoints(request)
+
+    # No `b`/breakable command was issued against the still-compiling file.
+    assert stub.commands == []
+    assert "/local/src/x.pl" in server._pending_breakpoints
+    out = _messages(writer)
+    resp = [m for m in out if m.get("command") == "setBreakpoints"][0]
+    assert resp["success"] is True
+    assert resp["body"]["breakpoints"] == [
+        {
+            "verified": False,
+            "line": 10,
+            "message": server_mod.DEFERRED_VERIFICATION_MESSAGE,
+        }
+    ]
+
+
 async def test_stackTrace_translates_remote_frame_paths_to_local():
     class StubSession:
         def __init__(self) -> None:

--- a/tests/unit/test_perl_dap_server.py
+++ b/tests/unit/test_perl_dap_server.py
@@ -314,6 +314,7 @@ async def test_ended_location_in_launch_mode_sends_q_and_reports_real_exit_code(
     class StubSession:
         stopped = True
         pid = 4242
+        eof = True  # `q` genuinely closed the connection
 
         def __init__(self) -> None:
             self.commands: list[str] = []
@@ -356,6 +357,7 @@ async def test_ended_location_in_launch_mode_dedupes_against_forwarded_eof():
     class StubSession:
         stopped = True
         pid = 4242
+        eof = True  # `q` genuinely closed the connection
 
         async def helper(self, expr, timeout=20.0):
             return {"file": "?", "line": 0}
@@ -379,6 +381,90 @@ async def test_ended_location_in_launch_mode_dedupes_against_forwarded_eof():
     assert len([m for m in out if m.get("event") == "terminated"]) == 1
     assert len([m for m in out if m.get("event") == "exited"]) == 1
     assert server._eof_terminated is False  # consumed, ready for next time
+
+
+async def test_location_error_in_launch_mode_does_not_send_q():
+    """Finding 1 (task-4 review): `location()` raising PerlProtocolError
+    (loc is None) covers timeouts / malformed JSON / mid-flight EOF -- NOT
+    only genuine termination. The debuggee could still be legitimately
+    stopped at a real breakpoint or pause, so this must NOT force-quit it
+    via `q`. It must still report termination (unchanged pre-existing
+    behavior for this branch) with exit code 0 (inconclusive)."""
+
+    class StubSession:
+        stopped = True
+        pid = 4242
+        eof = False
+
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+
+        async def helper(self, expr, timeout=20.0):
+            raise PerlProtocolError("timed out waiting for prompt")
+
+        async def command(self, text, timeout=20.0):
+            self.commands.append(text)
+            raise AssertionError("must not send a command when loc is None")
+
+        async def wait_exit_code(self) -> int:
+            raise AssertionError("must not be consulted when loc is None")
+
+    reader = asyncio.StreamReader()
+    writer = SinkWriter()
+    server = PerlDapServer(reader, writer)
+    stub = StubSession()
+    server.session = stub
+    server._on_unsolicited_stop()
+    await server._classify_task
+
+    assert stub.commands == [], "loc is None must never trigger `q`"
+    out = _messages(writer)
+    assert len([m for m in out if m.get("event") == "terminated"]) == 1
+    exited = [m for m in out if m.get("event") == "exited"]
+    assert len(exited) == 1
+    assert exited[0]["body"]["exitCode"] == 0
+
+
+async def test_q_without_eof_does_not_leave_eof_terminated_dangling():
+    """Finding 2 (task-4 review): if `command("q")` doesn't actually close
+    the connection (times out waiting for a prompt, or perl5db replies
+    without dying -- `session.eof` stays False either way), no `__eof__`
+    is coming to consume `_eof_terminated`. Leaving it set would silently
+    swallow the NEXT, genuinely unrelated `__eof__` termination (a
+    zero-emission failure). It must self-heal so that later `__eof__`
+    still emits exactly one terminated/exited pair."""
+
+    class StubSession:
+        stopped = True
+        pid = 4242
+        eof = False  # `q` never actually closed the connection
+
+        async def helper(self, expr, timeout=20.0):
+            return {"file": "?", "line": 0}
+
+        async def command(self, text, timeout=20.0):
+            raise PerlProtocolError("no prompt after command 'q'")  # timed out, no EOF
+
+        async def wait_exit_code(self) -> int:
+            return 0
+
+    reader = asyncio.StreamReader()
+    writer = SinkWriter()
+    server = PerlDapServer(reader, writer)
+    server.session = StubSession()
+    server._on_unsolicited_stop()
+    await server._classify_task
+
+    assert server._eof_terminated is False, "flag must not dangle after a non-EOF `q`"
+
+    # A later, genuinely unrelated EOF must still be reported -- not
+    # silently swallowed by a stale _eof_terminated flag.
+    server._forward_output("", "__eof__")
+    await server._eof_task
+
+    out = _messages(writer)
+    assert len([m for m in out if m.get("event") == "terminated"]) == 2
+    assert len([m for m in out if m.get("event") == "exited"]) == 2
 
 
 async def test_ended_location_in_attach_mode_reports_zero_without_sending_q():

--- a/tests/unit/test_perl_session_launch.py
+++ b/tests/unit/test_perl_session_launch.py
@@ -1,0 +1,137 @@
+"""Unit tests for PerlSession.launch()'s compile-shim availability gate.
+
+Final review (release-blocking finding, fixed WITHOUT touching
+pyproject.toml): pyproject.toml's package-data ships only helpers.pl and
+TdbRemote.pm, not Devel/TdbCompile.pm. Because launch() passed
+-MDevel::TdbCompile unconditionally, a built wheel installed non-editable
+would make perl abort at startup ("Can't locate Devel/TdbCompile.pm in
+@INC ... BEGIN failed") -- launch mode entirely broken, not merely
+missing BEGIN-block stepping. This covers the defensive fallback: when
+the shim file isn't present on disk, omit the -I/-M arguments and log a
+warning instead of crashing the debuggee's perl process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from tdb.adapters.perl import session as session_mod
+from tdb.adapters.perl.session import PerlSession
+
+
+class _FakeWriter:
+    def write(self, data: bytes) -> None:
+        pass
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeStream:
+    async def read(self, n: int) -> bytes:
+        return b""
+
+
+class _FakeProcess:
+    pid = 12345
+    returncode = 0
+    stdout = _FakeStream()
+    stderr = _FakeStream()
+
+    async def wait(self) -> int:
+        return 0
+
+
+async def _fake_start_server(client_connected_cb, host, port):
+    class _FakeSock:
+        def getsockname(self):
+            return ("127.0.0.1", 0)
+
+    class _FakeServer:
+        sockets = [_FakeSock()]
+
+        def close(self) -> None:
+            pass
+
+    reader = asyncio.StreamReader()
+    reader.feed_eof()  # so the background read loop finishes immediately
+    await client_connected_cb(reader, _FakeWriter())
+    return _FakeServer()
+
+
+def _make_session() -> PerlSession:
+    session = PerlSession(on_output=lambda *a: None, on_stop=lambda: None)
+
+    async def _noop_await_prompt(timeout: float) -> None:
+        pass
+
+    async def _noop_command(text: str, timeout: float = 20.0) -> list:
+        return []
+
+    session._await_prompt = _noop_await_prompt  # type: ignore[method-assign]
+    session.command = _noop_command  # type: ignore[method-assign]
+    return session
+
+
+async def test_launch_omits_compile_shim_when_file_missing(tmp_path, monkeypatch):
+    missing_shim = tmp_path / "nowhere" / "TdbCompile.pm"
+    monkeypatch.setattr(session_mod, "compile_shim_path", lambda: str(missing_shim))
+    monkeypatch.setattr(session_mod.asyncio, "start_server", _fake_start_server)
+
+    captured: dict = {}
+
+    async def fake_create_subprocess_exec(*argv, **kwargs):
+        captured["argv"] = argv
+        captured["env"] = kwargs.get("env")
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        session_mod.asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+    )
+
+    session = _make_session()
+    program = str(tmp_path / "prog.pl")
+    await session.launch(program=program, args=[], cwd=str(tmp_path), env=None)
+
+    argv = captured["argv"]
+    assert "-MDevel::TdbCompile" not in argv
+    assert not any(isinstance(a, str) and a.startswith("-I") for a in argv)
+    assert argv[0] == "perl"
+    assert argv[1] == "-d"
+    assert program in argv
+    assert "TDB_COMPILE_FILE" not in captured["env"]
+
+
+async def test_launch_includes_compile_shim_when_file_present(tmp_path, monkeypatch):
+    """Sanity check for the opposite branch: when the shim IS present
+    (the normal, non-broken-wheel case), -I/-M are still passed and
+    TDB_COMPILE_FILE is still set -- the fallback must not regress the
+    working path."""
+    present_shim = tmp_path / "TdbCompile.pm"
+    present_shim.parent.mkdir(parents=True, exist_ok=True)
+    present_shim.write_text("1;\n")
+    monkeypatch.setattr(session_mod, "compile_shim_path", lambda: str(present_shim))
+    monkeypatch.setattr(session_mod.asyncio, "start_server", _fake_start_server)
+
+    captured: dict = {}
+
+    async def fake_create_subprocess_exec(*argv, **kwargs):
+        captured["argv"] = argv
+        captured["env"] = kwargs.get("env")
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        session_mod.asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+    )
+
+    session = _make_session()
+    program = str(tmp_path / "prog.pl")
+    await session.launch(program=program, args=[], cwd=str(tmp_path), env=None)
+
+    argv = captured["argv"]
+    assert "-MDevel::TdbCompile" in argv
+    assert any(isinstance(a, str) and a.startswith("-I") for a in argv)
+    assert captured["env"]["TDB_COMPILE_FILE"] == program


### PR DESCRIPTION
Improve handling of `BEGIN` blocks -- specifically allow stepping into and setting breakponits.