### PR TITLE
Deep review fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ languages are supported out of the box:
 | Bash | bash-tdb (bundled) | bash ≥ 4.4 on PATH  | core debugging (no remote attach) |
 | Tcsh | tcsh-tdb (bundled) | tcsh on PATH | core debugging (no remote attach, no conditional breakpoints, no pause) |
 | Ruby | `rdbg` (the [debug gem](https://github.com/ruby/debug)) | `rdbg` ≥ 1.9 on PATH | core debugging + remote attach |
-| OCaml (native executable) | `lldb-dap` (default), `gdb` (alternate) | `lldb-dap` ships with LLVM ≥ 17; `gdb -i dap` requires GDB ≥ 14 | core debugging + domains-as-threads; Variables view shows no OCaml locals (upstream DWARF limitation); evaluate console is lldb/C-level, not OCaml |
-| OCaml (bytecode executable) | `ocamlearlybird` (default) | `opam install earlybird` | core debugging + rich OCaml locals; no pause/`--run`, no evaluate responses, no fatal-error modal (ocamlearlybird 1.3.6 limitations); single-domain only |
+| OCaml (native executable) | `lldb-dap` (default), `gdb` (alternate) | OCaml ≥ 4.12; `lldb-dap` ships with LLVM ≥ 17; `gdb -i dap` requires GDB ≥ 14 | core debugging + domains-as-threads; Variables view shows no OCaml locals (upstream DWARF limitation); evaluate console is lldb/C-level, not OCaml |
+| OCaml (bytecode executable) | `ocamlearlybird` (default) | OCaml ≥ 4.12; `opam install earlybird` | core debugging + rich OCaml locals; no pause/`--run`, no evaluate responses, no fatal-error modal (ocamlearlybird 1.3.6 limitations); single-domain only |
 
 ### Language detection and selection
 
@@ -634,6 +634,11 @@ from how the executable was built:
 does). Always pass the **built executable** to `tdb`, never the `.ml`
 source, as in `tdb ./_build/default/bin/main.exe`, not `tdb main.ml` (which
 errors with this exact guidance).
+
+**OCaml version:** tdb requires **OCaml ≥ 4.12**. Older runtimes print
+`Printexc` backtraces without function names, which the fatal-error
+modal's parser does not understand (frames would be dropped and the
+modal would wrongly suggest recompiling with `-g`).
 
 ```bash
 tdb ./_build/default/bin/main.exe          # native, lldb-dap

--- a/src/tdb/__init__.py
+++ b/src/tdb/__init__.py
@@ -1,6 +1,6 @@
 from tdb.breakpoint_hook import breakpoint
 from tdb.post_mortem import exception_hook
 
-__version__ = "0.2.7"  # trailing digit odd == dev version
+__version__ = "0.2.8"  # trailing digit odd == dev version
 
 __all__ = ["breakpoint", "exception_hook"]

--- a/src/tdb/adapters/perl/session.py
+++ b/src/tdb/adapters/perl/session.py
@@ -32,6 +32,14 @@ class PerlProtocolError(Exception):
         self.tail = tail
 
 
+def _perl_single_quote(value: str) -> str:
+    """Quote for a Perl single-quoted string literal. Backslash and the
+    quote itself are the only escapes; without them an apostrophe in the
+    install path breaks the `do` statement, and a Windows UNC path's
+    backslashes collapse."""
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
 def helpers_path() -> str:
     ref = importlib.resources.files("tdb.adapters.perl") / "helpers.pl"
     return str(ref)
@@ -212,7 +220,7 @@ class PerlSession:
         self._reader_task = asyncio.create_task(self._read_loop())
         await self._await_prompt(timeout=timeout, terminal=run_in_terminal is not None)
         self.stopped = True
-        await self.command(f"do '{helpers_path()}'")
+        await self.command(f"do {_perl_single_quote(helpers_path())}")
         if run_in_terminal is not None:
             reply = await self.command("p $$")
             # Fail-closed: pull the pid from the LAST non-empty line of the

--- a/src/tdb/languages/cpp.py
+++ b/src/tdb/languages/cpp.py
@@ -37,9 +37,12 @@ def _required_program(opts: dict[str, Any]) -> str:
     return program
 
 
-def _gdb_string(value: str) -> str:
-    """Quote one argument for a gdb CLI command that parses via buildargv
-    (e.g. `set substitute-path`)."""
+def quote_debugger_arg(value: str) -> str:
+    """Quote one argument for a gdb or lldb CLI command. Both parse
+    double-quoted arguments with backslash escapes (gdb via buildargv,
+    e.g. `set substitute-path`; lldb e.g. `command script import`).
+    Shared by the rust and ocaml profiles — keep semantics in sync with
+    both debuggers when changing."""
     return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
 
@@ -167,7 +170,7 @@ class GdbDapAdapter(AdapterSpec):
         self, path_mappings: list[tuple[str, str]]
     ) -> tuple[str, ...]:
         return tuple(
-            f"set substitute-path {_gdb_string(remote)} {_gdb_string(local)}"
+            f"set substitute-path {quote_debugger_arg(remote)} {quote_debugger_arg(local)}"
             for local, remote in path_mappings
         )
 

--- a/src/tdb/languages/errors.py
+++ b/src/tdb/languages/errors.py
@@ -344,11 +344,16 @@ def parse_ruby_error(stderr: str, exit_code: int | None = None) -> ParsedError |
 _OCAML_FATAL_RE = re.compile(r"^Fatal error: exception (?P<msg>.+?)\s*$", re.MULTILINE)
 # A frame spanning several source lines prints "lines N-M" (plural) —
 # stdlib format string is `... in file "%s"%s, line%s, characters %d-%d`
-# where line%s becomes " N" or "s N-M". Capture the first line of a span.
+# where line%s becomes " N" or "s N-M". The frame anchors at the span's
+# first line; the "-M" tail is deliberately left unconsumed (every match
+# is ^-anchored, so it can't corrupt the next one). The "<func> in file"
+# segment requires OCaml >= 4.12 — Printexc gained function names there,
+# and that is tdb's documented OCaml floor (see README); older runtimes'
+# backtraces parse as header-only.
 _OCAML_FRAME_RE = re.compile(
     r"^(?:Raised at|Raised by primitive operation at|Re-raised at"
     r"|Called from) (?P<func>.+?) in file \"(?P<path>[^\"]+)\""
-    r"(?: \(inlined\))?, lines? (?P<line>\d+)(?:-\d+)?",
+    r"(?: \(inlined\))?, lines? (?P<line>\d+)",
     re.MULTILINE,
 )
 

--- a/src/tdb/languages/ocaml.py
+++ b/src/tdb/languages/ocaml.py
@@ -24,7 +24,7 @@ from tdb.languages.base import (
     ProfileCapabilities,
     ThreadDecoration,
 )
-from tdb.languages.cpp import GdbDapAdapter, LldbDapAdapter, _gdb_string
+from tdb.languages.cpp import GdbDapAdapter, LldbDapAdapter, quote_debugger_arg
 from tdb.languages.errors import parse_ocaml_error
 
 _BYTECODE_TRAILER_MARK = b"Caml1999"  # e.g. b"Caml1999X033" at file end
@@ -200,7 +200,7 @@ class OCamlLldbAdapter(LldbDapAdapter):
             opts=opts,
         )
         body["initCommands"] = [
-            f"command script import {_gdb_string(formatter_script_path())}",
+            f"command script import {quote_debugger_arg(formatter_script_path())}",
         ]
         body["preRunCommands"] = [
             "breakpoint set --name caml_fatal_uncaught_exception",

--- a/src/tdb/languages/rust.py
+++ b/src/tdb/languages/rust.py
@@ -18,7 +18,7 @@ from tdb.languages.base import (
     Presentation,
     ProfileCapabilities,
 )
-from tdb.languages.cpp import GdbDapAdapter, LldbDapAdapter, _gdb_string
+from tdb.languages.cpp import GdbDapAdapter, LldbDapAdapter, quote_debugger_arg
 from tdb.languages.errors import parse_rust_error
 
 
@@ -92,7 +92,7 @@ class RustLldbAdapter(LldbDapAdapter):
         script_path = resources.files("tdb.rust_concurrency.probes").joinpath(
             "lldb_script.py"
         )
-        return [f"command script import {_gdb_string(str(script_path))}"]
+        return [f"command script import {quote_debugger_arg(str(script_path))}"]
 
     def launch_body(
         self,

--- a/tests/unit/test_ocaml_profile.py
+++ b/tests/unit/test_ocaml_profile.py
@@ -3,6 +3,7 @@ import sys
 import pytest
 
 from tdb.languages.base import LanguageNotSupportedError
+from tdb.languages.cpp import quote_debugger_arg
 from tdb.languages.ocaml import (
     EarlybirdAdapter,
     OCamlLldbAdapter,
@@ -27,14 +28,14 @@ def _native_launch_body(adapter):
 def test_lldb_launch_body_injects_formatters_and_runparam():
     body = _native_launch_body(OCamlLldbAdapter())
     assert body["program"] == "/x/main.exe"
-    assert any(
-        "command script import" in c and "lldb_formatters.py" in c
-        for c in body["initCommands"]
-    )
     # The script path must be quoted — an install path containing a
     # space (e.g. a venv under "My Projects") would otherwise split
-    # into multiple lldb arguments.
-    assert f'command script import "{formatter_script_path()}"' in body["initCommands"]
+    # into multiple lldb arguments. Build the expectation with the same
+    # helper production uses so Windows backslash-doubling matches too.
+    assert (
+        f"command script import {quote_debugger_arg(formatter_script_path())}"
+        in body["initCommands"]
+    )
     assert any(
         "caml_fatal_uncaught_exception" in c for c in body.get("preRunCommands", [])
     )

--- a/tests/unit/test_perl_session_launch.py
+++ b/tests/unit/test_perl_session_launch.py
@@ -200,3 +200,43 @@ async def test_launch_terminal_mode_pid_parse_fails_closed_on_stray_digit(
 
     assert session.debuggee_pid is None
     assert "could not parse debuggee pid" in caplog.text
+
+
+async def test_launch_quotes_helpers_path_for_perl(tmp_path, monkeypatch):
+    """helpers_path() is spliced into a Perl single-quoted string; a path
+    containing an apostrophe (or backslashes, e.g. a Windows UNC share)
+    must be escaped or the `do` statement misparses and helpers.pl never
+    loads (same bug class as the OCaml `command script import` quoting)."""
+    monkeypatch.setattr(
+        session_mod, "helpers_path", lambda: "/home/o'brien/helpers.pl"
+    )
+    monkeypatch.setattr(session_mod.asyncio, "start_server", _fake_start_server)
+
+    async def fake_create_subprocess_exec(*argv, **kwargs):
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        session_mod.asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+    )
+
+    session = _make_session()
+    sent: list[str] = []
+
+    async def capture_command(text: str, timeout: float = 20.0) -> list:
+        sent.append(text)
+        return []
+
+    session.command = capture_command  # type: ignore[method-assign]
+    program = str(tmp_path / "prog.pl")
+    await session.launch(program=program, args=[], cwd=str(tmp_path), env=None)
+
+    assert r"do '/home/o\'brien/helpers.pl'" in sent
+
+
+def test_perl_single_quote_escapes_backslashes():
+    # Windows UNC path: perl single-quote strings collapse \\ to \, so
+    # every backslash must be doubled to round-trip.
+    assert (
+        session_mod._perl_single_quote("\\\\server\\share\\h.pl")
+        == "'\\\\\\\\server\\\\share\\\\h.pl'"
+    )


### PR DESCRIPTION
- require OCaml >= 4.12 
- make gdb string quoting general to apply to C++, Rust, OCaml
- fix Perl `do` statement parsing